### PR TITLE
feat: company-scoped nav header + anon questionnaire hardening

### DIFF
--- a/src/components/CompanyAuthGate.jsx
+++ b/src/components/CompanyAuthGate.jsx
@@ -1,13 +1,55 @@
 import { useParams, Navigate, useLocation } from 'react-router-dom'
+import { toast } from 'sonner'
+import { useEffect } from 'react'
 import authService from '@/services/authService'
 
 export default function CompanyAuthGate({ children }) {
   const { slug } = useParams()
   const location = useLocation()
 
-  if (!authService.isLoggedIn()) {
+  const isLoggedIn = authService.isLoggedIn()
+  const user = isLoggedIn ? authService.getUser() : null
+
+  // Pre-update clients may have a cached user object without company_slug.
+  // Refresh from /auth/me so the next render has authoritative data.
+  const isClientMissingSlug =
+    user?.user_type === 'client' && user.company_slug === undefined
+  useEffect(() => {
+    if (isClientMissingSlug) {
+      authService.getCurrentUser().then((fresh) => {
+        if (fresh) localStorage.setItem('user', JSON.stringify(fresh))
+      })
+    }
+  }, [isClientMissingSlug])
+
+  // Only block on explicit mismatch: company_slug present and different, or
+  // explicitly null (client with no company at all).
+  const hasResolvedSlug =
+    user?.user_type === 'client' && user.company_slug !== undefined
+  const isClientFromOtherCompany =
+    hasResolvedSlug && user.company_slug && user.company_slug !== slug
+  const isClientWithNoCompany =
+    hasResolvedSlug && !user.company_slug
+
+  useEffect(() => {
+    if (isClientFromOtherCompany) {
+      toast.error('Esta área pertence a outra empresa. Redirecionando para a sua.')
+    } else if (isClientWithNoCompany) {
+      toast.error('Sua conta não está vinculada a esta empresa.')
+    }
+  }, [isClientFromOtherCompany, isClientWithNoCompany])
+
+  if (!isLoggedIn) {
     const redirect = encodeURIComponent(location.pathname + location.search)
     return <Navigate to={`/empresa/${slug}/login?redirect=${redirect}`} replace />
+  }
+
+  if (isClientFromOtherCompany) {
+    return <Navigate to={`/empresa/${user.company_slug}`} replace />
+  }
+
+  if (isClientWithNoCompany) {
+    return <Navigate to={`/empresa/${slug}/login`} replace />
   }
 
   return children

--- a/src/components/CompanyHeader.jsx
+++ b/src/components/CompanyHeader.jsx
@@ -1,0 +1,119 @@
+import { Link, useLocation } from 'react-router-dom'
+import { LogIn, LogOut, Users, ClipboardList, BarChart3 } from 'lucide-react'
+import { Button } from '@/components/ui/button.jsx'
+import authService from '@/services/authService'
+import horizontalLogo from '../assets/horizontal-logo.png'
+
+export default function CompanyHeader({ company, slug, rightSlot = null }) {
+  const location = useLocation()
+  const isLoggedIn = authService.isLoggedIn()
+  const primaryColor = company?.primary_color || '#4f46e5'
+
+  const base = `/empresa/${slug}`
+  // Questionário nav targets the company's anonymous NR-1 questionnaire —
+  // hide it for logged-in users; their identity would break the anonymity.
+  const navItems = [
+    { to: `${base}/psicologos`, label: 'Psicólogos', icon: Users, match: '/psicologos' },
+    !isLoggedIn && company?.questionnaire_slug && {
+      to: `${base}/questionario/${company.questionnaire_slug}`,
+      label: 'Questionário',
+      icon: ClipboardList,
+      match: '/questionario/'
+    },
+    { to: `${base}/rh`, label: 'RH', icon: BarChart3, match: '/rh' }
+  ].filter(Boolean)
+
+  const isActive = (match) => location.pathname.startsWith(`${base}${match}`)
+
+  const handleLogout = () => {
+    authService.logout()
+    window.location.href = base
+  }
+
+  return (
+    <header className="bg-white shadow-sm sticky top-0 z-50">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+        <div className="flex justify-between items-center gap-4">
+          {/* Logo */}
+          <Link to={base} className="flex-shrink-0">
+            <img
+              src={company?.logo_url || horizontalLogo}
+              alt={company?.logo_url ? `${company.name} Logo` : 'Terapia Conecta Logo'}
+              className="h-8 object-contain"
+            />
+          </Link>
+
+          {/* Nav (hidden on mobile) */}
+          <nav className="hidden md:flex items-center gap-1">
+            {navItems.map(({ to, label, icon: Icon, match }) => {
+              const active = isActive(match)
+              return (
+                <Link
+                  key={to}
+                  to={to}
+                  className="inline-flex items-center gap-1.5 text-sm font-medium px-3 py-1.5 rounded-md transition-colors"
+                  style={
+                    active
+                      ? { color: primaryColor, backgroundColor: `${primaryColor}12` }
+                      : { color: '#4b5563' }
+                  }
+                >
+                  <Icon className="h-4 w-4" />
+                  {label}
+                </Link>
+              )
+            })}
+          </nav>
+
+          {/* Right side */}
+          <div className="flex items-center gap-2">
+            {rightSlot}
+            {company?.name && (
+              <span
+                className="hidden sm:inline text-xs font-medium px-3 py-1 rounded-full"
+                style={{ backgroundColor: `${primaryColor}15`, color: primaryColor }}
+              >
+                {company.name}
+              </span>
+            )}
+            {isLoggedIn ? (
+              <Button variant="outline" size="sm" onClick={handleLogout} className="gap-1.5">
+                <LogOut className="h-4 w-4" />
+                <span className="hidden sm:inline">Sair</span>
+              </Button>
+            ) : (
+              <Link to={`${base}/login`}>
+                <Button variant="outline" size="sm" className="gap-1.5">
+                  <LogIn className="h-4 w-4" />
+                  <span className="hidden sm:inline">Entrar</span>
+                </Button>
+              </Link>
+            )}
+          </div>
+        </div>
+
+        {/* Mobile nav */}
+        <nav className="md:hidden flex items-center gap-1 mt-2 -mb-1 overflow-x-auto">
+          {navItems.map(({ to, label, icon: Icon, match }) => {
+            const active = isActive(match)
+            return (
+              <Link
+                key={to}
+                to={to}
+                className="inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1.5 rounded-md whitespace-nowrap"
+                style={
+                  active
+                    ? { color: primaryColor, backgroundColor: `${primaryColor}12` }
+                    : { color: '#4b5563' }
+                }
+              >
+                <Icon className="h-3.5 w-3.5" />
+                {label}
+              </Link>
+            )
+          })}
+        </nav>
+      </div>
+    </header>
+  )
+}

--- a/src/pages/CompanyLandingPage.jsx
+++ b/src/pages/CompanyLandingPage.jsx
@@ -2,9 +2,9 @@ import { useState, useEffect } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { Button } from '@/components/ui/button.jsx'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card.jsx'
-import { ClipboardList, UserCheck, HeartHandshake, ArrowRight, Star, Loader2, LogIn } from 'lucide-react'
+import { ClipboardList, UserCheck, HeartHandshake, ArrowRight, Star, Loader2 } from 'lucide-react'
 import companyService from '@/services/companyService'
-import horizontalLogo from '../assets/horizontal-logo.png'
+import CompanyHeader from '@/components/CompanyHeader.jsx'
 
 export default function CompanyLandingPage() {
   const { slug } = useParams()
@@ -52,34 +52,7 @@ export default function CompanyLandingPage() {
 
   return (
     <div className="min-h-screen bg-white">
-      {/* Header */}
-      <header className="bg-white shadow-sm sticky top-0 z-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-          <div className="flex justify-between items-center">
-            <img
-              src={company.logo_url || horizontalLogo}
-              alt={company.logo_url ? `${company.name} Logo` : 'Terapia Conecta Logo'}
-              className="h-8 object-contain"
-            />
-            <div className="flex items-center gap-3">
-              {company.name && (
-                <span
-                  className="text-sm font-medium px-3 py-1 rounded-full"
-                  style={{ backgroundColor: `${primaryColor}15`, color: primaryColor }}
-                >
-                  {company.name}
-                </span>
-              )}
-              <Link to={`/empresa/${slug}/login`}>
-                <Button variant="outline" size="sm" className="gap-1.5">
-                  <LogIn className="h-4 w-4" />
-                  Entrar
-                </Button>
-              </Link>
-            </div>
-          </div>
-        </div>
-      </header>
+      <CompanyHeader company={company} slug={slug} />
 
       {/* Hero */}
       <section

--- a/src/pages/CompanyMatchingPage.jsx
+++ b/src/pages/CompanyMatchingPage.jsx
@@ -4,7 +4,7 @@ import { Card, CardContent } from '@/components/ui/card.jsx'
 import { Button } from '@/components/ui/button.jsx'
 import { Star, Calendar, Loader2, Users } from 'lucide-react'
 import companyService from '@/services/companyService'
-import horizontalLogo from '../assets/horizontal-logo.png'
+import CompanyHeader from '@/components/CompanyHeader.jsx'
 
 export default function CompanyMatchingPage() {
   const { slug } = useParams()
@@ -71,26 +71,7 @@ export default function CompanyMatchingPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <header className="bg-white shadow-sm">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-          <div className="flex justify-between items-center">
-            <Link to={`/empresa/${slug}`}>
-              <img
-                src={company.logo_url || horizontalLogo}
-                alt={company.logo_url ? `${company.name} Logo` : 'Terapia Conecta Logo'}
-                className="h-8 object-contain"
-              />
-            </Link>
-            <span
-              className="text-sm font-medium px-3 py-1 rounded-full"
-              style={{ backgroundColor: `${primaryColor}15`, color: primaryColor }}
-            >
-              {company.name}
-            </span>
-          </div>
-        </div>
-      </header>
+      <CompanyHeader company={company} slug={slug} />
 
       {/* Hero */}
       <section

--- a/src/pages/CompanyRegisterPage.jsx
+++ b/src/pages/CompanyRegisterPage.jsx
@@ -159,17 +159,15 @@ export default function CompanyRegisterPage() {
                 Nossa equipe de psicólogos entrará em contato em breve.
               </p>
               <div className="space-y-3">
-                {company.questionnaire_slug && (
-                  <Link to={`/empresa/${slug}/questionario/${company.questionnaire_slug}`}>
-                    <Button
-                      className="w-full text-white gap-2"
-                      style={{ backgroundColor: primaryColor }}
-                    >
-                      <ClipboardList className="h-4 w-4" />
-                      Preencher Questionário Psicossocial
-                    </Button>
-                  </Link>
-                )}
+                <Link to={`/empresa/${slug}/questionario/questionario-de-acolhimento`}>
+                  <Button
+                    className="w-full text-white gap-2"
+                    style={{ backgroundColor: primaryColor }}
+                  >
+                    <ClipboardList className="h-4 w-4" />
+                    Questionário de Acolhimento
+                  </Button>
+                </Link>
                 <Link to={`/empresa/${slug}/psicologos`}>
                   <Button
                     variant="outline"

--- a/src/pages/HrDashboardPage.jsx
+++ b/src/pages/HrDashboardPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react'
-import { useParams, Link } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card.jsx'
 import { Badge } from '@/components/ui/badge.jsx'
 import { Button } from '@/components/ui/button.jsx'
@@ -8,7 +8,7 @@ import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/
 import {
   Users, UserCheck, AlertTriangle, Calendar,
   Shield, ShieldCheck, Download, TrendingUp, TrendingDown,
-  Loader2, Activity, ArrowUpRight, ArrowDownRight,
+  Loader2, ArrowUpRight, ArrowDownRight,
   Moon, Repeat, GraduationCap, Lightbulb, Target, BarChart3
 } from 'lucide-react'
 import {
@@ -19,7 +19,7 @@ import {
 } from 'recharts'
 import { toast } from 'sonner'
 import companyService from '@/services/companyService'
-import horizontalLogo from '../assets/horizontal-logo.png'
+import CompanyHeader from '@/components/CompanyHeader.jsx'
 
 function riskColor(score) {
   if (score < 4) return '#22c55e'
@@ -147,39 +147,7 @@ export default function HrDashboardPage() {
 
   return (
     <div className="min-h-screen bg-slate-50">
-      {/* ── Header ───────────────────────────────────────── */}
-      <header
-        className="sticky top-0 z-50 border-b"
-        style={{ backgroundColor: 'white', borderColor: `${primaryColor}20` }}
-      >
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
-          <div className="flex justify-between items-center">
-            <div className="flex items-center gap-3">
-              <Link to={`/empresa/${slug}`}>
-                <img
-                  src={company.logo_url || horizontalLogo}
-                  alt={company.logo_url ? `${company.name} Logo` : 'Terapia Conecta'}
-                  className="h-7 object-contain"
-                />
-              </Link>
-              <div
-                className="w-px h-6"
-                style={{ backgroundColor: `${primaryColor}30` }}
-              />
-              <div className="flex items-center gap-2">
-                <Activity className="h-4 w-4" style={{ color: primaryColor }} />
-                <span className="text-sm font-semibold text-gray-900">Painel RH</span>
-              </div>
-            </div>
-            <span
-              className="text-xs font-medium px-3 py-1.5 rounded-full"
-              style={{ backgroundColor: `${primaryColor}12`, color: primaryColor }}
-            >
-              {company.name}
-            </span>
-          </div>
-        </div>
-      </header>
+      <CompanyHeader company={company} slug={slug} />
 
       {/* ── Title Banner ─────────────────────────────────── */}
       <section

--- a/src/pages/QuestionnaireFormPage.jsx
+++ b/src/pages/QuestionnaireFormPage.jsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import * as z from 'zod'
-import { Loader2, ChevronLeft, ChevronRight, CheckCircle2, Send } from 'lucide-react'
+import { Loader2, ChevronLeft, ChevronRight, CheckCircle2, Send, Shield, LogOut } from 'lucide-react'
 
 import { Button } from '@/components/ui/button.jsx'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card.jsx'
@@ -22,7 +22,8 @@ import {
 } from '@/components/ui/form.jsx'
 import companyService from '@/services/companyService'
 import questionnaireService from '@/services/questionnaireService'
-import horizontalLogo from '../assets/horizontal-logo.png'
+import authService from '@/services/authService'
+import CompanyHeader from '@/components/CompanyHeader.jsx'
 
 function buildZodSchema(questions) {
   const shape = {}
@@ -333,6 +334,7 @@ export default function QuestionnaireFormPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const [currentSectionIndex, setCurrentSectionIndex] = useState(0)
+  const [isAdvancing, setIsAdvancing] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [submitted, setSubmitted] = useState(false)
 
@@ -401,12 +403,21 @@ export default function QuestionnaireFormPage() {
     : 0
 
   const handleNext = async () => {
-    if (!currentSection) return
-    const fieldNames = currentSection.questions.map((q) => q.id)
-    const isValid = await form.trigger(fieldNames)
-    if (isValid) {
-      setCurrentSectionIndex((i) => i + 1)
-      window.scrollTo({ top: 0, behavior: 'smooth' })
+    // Guard against rapid re-triggers: a fast double-click could land on the
+    // Enviar button after React swaps the button's type on section change,
+    // causing the form to submit before the user sees the final section.
+    if (isAdvancing || !currentSection) return
+    setIsAdvancing(true)
+    try {
+      const fieldNames = currentSection.questions.map((q) => q.id)
+      const isValid = await form.trigger(fieldNames)
+      if (isValid) {
+        setCurrentSectionIndex((i) => i + 1)
+        window.scrollTo({ top: 0, behavior: 'smooth' })
+      }
+    } finally {
+      // Short window absorbs any trailing click from the same gesture.
+      setTimeout(() => setIsAdvancing(false), 350)
     }
   }
 
@@ -452,28 +463,52 @@ export default function QuestionnaireFormPage() {
   const accentColor = secondaryColor || primaryColor
   const highlightColor = primaryColor
 
+  // Anonymous questionnaires reject logged-in submissions — block before the form renders.
+  if (questionnaire?.allow_anonymous && authService.isLoggedIn()) {
+    const handleLogoutAndStay = () => {
+      authService.logout()
+      window.location.reload()
+    }
+
+    return (
+      <div className="min-h-screen bg-gray-50" style={{ '--primary': accentColor, '--primary-foreground': '#ffffff' }}>
+        <CompanyHeader company={company} slug={slug} />
+        <div className="flex items-center justify-center py-16 px-4">
+          <Card className="w-full max-w-md text-center">
+            <CardContent className="p-8">
+              <div
+                className="w-16 h-16 rounded-full mx-auto mb-6 flex items-center justify-center"
+                style={{ backgroundColor: `${highlightColor}20` }}
+              >
+                <Shield className="h-8 w-8" style={{ color: accentColor }} />
+              </div>
+              <h2 className="text-2xl font-bold text-gray-900 mb-2">Questionário anônimo</h2>
+              <p className="text-gray-600 mb-6">
+                Este questionário é 100% anônimo — respostas não são vinculadas a usuários identificados.
+                Para participar, saia da sua conta e acesse novamente.
+              </p>
+              <Button
+                onClick={handleLogoutAndStay}
+                className="w-full gap-2 text-white"
+                style={{ backgroundColor: accentColor }}
+              >
+                <LogOut className="h-4 w-4" />
+                Sair e responder anonimamente
+              </Button>
+              <p className="text-xs text-gray-400 mt-4">
+                Você pode voltar para a sua conta a qualquer momento.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    )
+  }
+
   if (submitted) {
     return (
       <div className="min-h-screen bg-gray-50" style={{ '--primary': accentColor, '--primary-foreground': '#ffffff' }}>
-        <header className="bg-white shadow-sm">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-            <div className="flex justify-between items-center">
-              <img
-                src={company?.logo_url || horizontalLogo}
-                alt={company?.logo_url ? `${company.name} Logo` : 'Terapia Conecta Logo'}
-                className="h-8 object-contain"
-              />
-              {company?.name && (
-                <span
-                  className="text-sm font-medium px-3 py-1 rounded-full"
-                  style={{ backgroundColor: `${highlightColor}20`, color: accentColor }}
-                >
-                  {company.name}
-                </span>
-              )}
-            </div>
-          </div>
-        </header>
+        <CompanyHeader company={company} slug={slug} />
 
         <div className="flex items-center justify-center py-16 px-4">
           <Card className="w-full max-w-md text-center">
@@ -501,26 +536,7 @@ export default function QuestionnaireFormPage() {
 
   return (
     <div className="min-h-screen bg-gray-50" style={{ '--primary': accentColor, '--primary-foreground': '#ffffff' }}>
-      {/* Header */}
-      <header className="bg-white shadow-sm sticky top-0 z-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-          <div className="flex justify-between items-center">
-            <img
-              src={company?.logo_url || horizontalLogo}
-              alt={company?.logo_url ? `${company.name} Logo` : 'Terapia Conecta Logo'}
-              className="h-8 object-contain"
-            />
-            {company?.name && (
-              <span
-                className="text-sm font-medium px-3 py-1 rounded-full"
-                style={{ backgroundColor: `${highlightColor}20`, color: accentColor }}
-              >
-                {company.name}
-              </span>
-            )}
-          </div>
-        </div>
-      </header>
+      <CompanyHeader company={company} slug={slug} />
 
       <div className="max-w-2xl mx-auto py-8 px-4">
         {/* Title + Progress */}
@@ -540,7 +556,10 @@ export default function QuestionnaireFormPage() {
         {/* Section Card */}
         <Form {...form}>
           <form onSubmit={form.handleSubmit(handleSubmit)}>
-            <Card>
+            {/* key per-section forces a fresh DOM subtree on each transition.
+                Prevents React removeChild crashes when extensions (Translate,
+                password managers) have mutated the previous section's DOM. */}
+            <Card key={`section-${currentSectionIndex}`}>
               <CardHeader>
                 <CardTitle className="text-lg">{currentSection?.name}</CardTitle>
                 <CardDescription>
@@ -583,8 +602,9 @@ export default function QuestionnaireFormPage() {
 
               {isLastSection ? (
                 <Button
+                  key="submit-button"
                   type="submit"
-                  disabled={isSubmitting}
+                  disabled={isSubmitting || isAdvancing}
                   className="gap-2 text-white"
                   style={{ backgroundColor: accentColor }}
                 >
@@ -602,9 +622,10 @@ export default function QuestionnaireFormPage() {
                 </Button>
               ) : (
                 <Button
+                  key="next-button"
                   type="button"
                   onClick={handleNext}
-                  disabled={consentDeclined}
+                  disabled={consentDeclined || isAdvancing}
                   className="gap-2 text-white"
                   style={{ backgroundColor: consentDeclined ? undefined : accentColor }}
                 >

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -138,7 +138,7 @@ export const router = createBrowserRouter([
   },
   {
     path: "/empresa/:slug/questionario/:questionnaire_slug",
-    element: <CompanyAuthGate><QuestionnaireFormPage /></CompanyAuthGate>
+    element: <QuestionnaireFormPage />
   },
   {
     path: "/therapist/questionarios/:slug/respostas",


### PR DESCRIPTION
## Summary
- Shared `CompanyHeader` (Psicólogos / Questionário / RH) applied across the 4 `/empresa/:slug` journey pages. Questionnaire route unwrapped from `CompanyAuthGate` so anonymous visitors can reach it.
- `CompanyAuthGate` now enforces cross-company access: clients whose `company_slug` doesn't match the URL slug are redirected to their own company's landing. Pre-update cached sessions fall back gracefully (silent `/auth/me` refresh).
- `QuestionnaireFormPage` blocks logged-in users on `allow_anonymous` questionnaires (offers logout CTA). Post-cadastro onboarding CTA swapped from the anon NR-1 to `questionario-de-acolhimento`.
- Hardens section transitions: per-section `Card key`, distinct keys on Próximo/Enviar, 350ms `isAdvancing` guard. Fixes the observed section-9-jumps-to-submitted bug alongside the `removeChild` error.

## Depends on
Backend PR: https://github.com/monoxchd/psicologia-platform-api/pull/46 (needs `company_slug` in auth payload + `allow_anonymous` in questionnaire show).

## Test plan
- [ ] `/empresa/ekoa` → header shows Psicólogos / Questionário / RH, active route highlighted
- [ ] Anon visit to `/empresa/ekoa/questionario/diagnostico-psicossocial-ekoa` — walk all 10 sections, submit → "Respostas enviadas!"
- [ ] Logged-in Ekoa client → Questionário nav hidden; direct URL shows "Questionário anônimo" block screen with "Sair e responder" CTA
- [ ] Logged-in Ekoa client browsing `/empresa/wtc-express/psicologos` → redirected to `/empresa/ekoa` with toast
- [ ] Post-cadastro success screen → "Questionário de Acolhimento" button links to `/empresa/ekoa/questionario/questionario-de-acolhimento`
- [ ] Rapidly double-click Próximo on section 9 — does not jump to submitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)