### PR TITLE
feat: privacy-forward hero + filter-first therapist discovery UX

### DIFF
--- a/src/components/EnigmaQuizInline.jsx
+++ b/src/components/EnigmaQuizInline.jsx
@@ -4,9 +4,10 @@ import { Input } from '@/components/ui/input.jsx'
 import { Label } from '@/components/ui/label.jsx'
 import { MessageCircle, ArrowRight, Lock, Eye, Heart, Sparkles } from 'lucide-react'
 import api from '../services/api'
+import { openWhatsApp } from '../utils/whatsapp'
+import { track } from '../services/analytics'
 
 const CORRECT_ANSWER = '33'
-const WHATSAPP_NUMBER = '5511914214449'
 
 const fonts = {
   serif: "'EB Garamond', Georgia, serif",
@@ -117,10 +118,13 @@ export default function EnigmaQuizInline() {
   }
 
   const handleWhatsAppClick = () => {
-    const message = encodeURIComponent(
-      `Oi! Descobri o enigma escondido no artigo sobre luto no trabalho. O texto me tocou e gostaria de conversar com um psicólogo.`
-    )
-    window.open(`https://wa.me/${WHATSAPP_NUMBER}?text=${message}`, '_blank')
+    track('WhatsApp Click', {
+      source: 'enigma_quiz_inline',
+      path: window.location.pathname,
+    })
+    openWhatsApp({
+      message: `Oi! Descobri o enigma escondido no artigo sobre luto no trabalho. O texto me tocou e gostaria de conversar com um psicólogo.`,
+    })
   }
 
   // ── Success state ──

--- a/src/components/ExitIntentModal.jsx
+++ b/src/components/ExitIntentModal.jsx
@@ -16,7 +16,8 @@ import { track } from '../services/analytics'
  * ExitIntentModal
  *
  * Gentle "before you leave" modal. Designed to pair with useExitIntent.
- * Renders a badge, headline, short body, primary CTA, and a soft dismiss link.
+ * Renders a badge, headline, short body, primary CTA, optional secondary CTA,
+ * and a soft dismiss link.
  *
  * @param {Object} props
  * @param {Boolean} props.open
@@ -27,6 +28,7 @@ import { track } from '../services/analytics'
  * @param {String} props.ctaLabel
  * @param {String} props.ctaTo - react-router `to` for the primary CTA
  * @param {Object} [props.ctaState] - optional `state` passed to the Link
+ * @param {React.ReactNode} [props.secondary] - optional secondary CTA slot (e.g., WhatsAppButton)
  * @param {String} [props.dismissLabel='Não, obrigado']
  */
 export default function ExitIntentModal({
@@ -38,6 +40,7 @@ export default function ExitIntentModal({
   ctaLabel,
   ctaTo,
   ctaState,
+  secondary,
   dismissLabel = 'Não, obrigado',
 }) {
   // Track whether the close was triggered by a CTA click vs a dismissal
@@ -96,6 +99,9 @@ export default function ExitIntentModal({
             {ctaLabel}
             <ArrowRight className="h-4 w-4" />
           </Link>
+          {secondary && (
+            <div className="w-full">{secondary}</div>
+          )}
           <a
             href="#"
             onClick={handleDismiss}

--- a/src/components/ExitIntentModal.jsx
+++ b/src/components/ExitIntentModal.jsx
@@ -100,7 +100,15 @@ export default function ExitIntentModal({
             <ArrowRight className="h-4 w-4" />
           </Link>
           {secondary && (
-            <div className="w-full">{secondary}</div>
+            <div
+              className="w-full"
+              // Any click inside the secondary slot counts as a CTA-driven close —
+              // setting the ref here means the modal's handleOpenChange won't
+              // later fire 'Exit Modal Dismissed' and pollute the dismissal metric.
+              onClickCapture={() => { ctaClickedRef.current = true }}
+            >
+              {secondary}
+            </div>
           )}
           <a
             href="#"

--- a/src/components/PrivacyStrip.jsx
+++ b/src/components/PrivacyStrip.jsx
@@ -1,0 +1,58 @@
+import { ShieldCheck, BarChart3, Handshake } from 'lucide-react'
+
+const PROMISES = [
+  {
+    icon: ShieldCheck,
+    title: 'Sem ads no seu sofrimento',
+    body: 'Você não vê anúncios de depressão depois de ler sobre depressão. Aqui não tem isso.',
+  },
+  {
+    icon: BarChart3,
+    title: 'Sem Google Analytics',
+    body: 'Usamos Plausible: métricas anônimas, hospedadas na Europa. Respeitamos o seu anonimato.',
+  },
+  {
+    icon: Handshake,
+    title: 'Seus dados não são vendidos',
+    body: 'Nunca foram, nunca serão. Sua busca por cuidado não vira produto de ninguém.',
+  },
+]
+
+export default function PrivacyStrip() {
+  return (
+    <section
+      aria-labelledby="privacy-strip-heading"
+      className="bg-white border-y border-gray-100"
+    >
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="text-center mb-8">
+          <p className="text-xs font-semibold uppercase tracking-widest text-emerald-700 mb-2">
+            Privacidade de verdade
+          </p>
+          <h2
+            id="privacy-strip-heading"
+            className="text-2xl sm:text-3xl font-semibold text-gray-900"
+          >
+            Buscar ajuda é um ato íntimo — e a gente trata assim.
+          </h2>
+        </div>
+        <div className="grid md:grid-cols-3 gap-6">
+          {PROMISES.map(({ icon: Icon, title, body }) => (
+            <div
+              key={title}
+              className="flex gap-4 p-5 rounded-xl bg-emerald-50/40 border border-emerald-100"
+            >
+              <div className="shrink-0 w-10 h-10 rounded-lg bg-white border border-emerald-100 flex items-center justify-center">
+                <Icon className="h-5 w-5 text-emerald-700" />
+              </div>
+              <div>
+                <p className="font-semibold text-gray-900 mb-1">{title}</p>
+                <p className="text-sm text-gray-600 leading-relaxed">{body}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/WhatsAppButton.jsx
+++ b/src/components/WhatsAppButton.jsx
@@ -1,0 +1,49 @@
+import { Button } from '@/components/ui/button.jsx'
+import { MessageCircle } from 'lucide-react'
+import { buildWhatsAppUrl } from '../utils/whatsapp'
+import { track } from '../services/analytics'
+
+export default function WhatsAppButton({
+  message,
+  label = 'Falar no WhatsApp',
+  source,
+  variant = 'default',
+  size = 'default',
+  className = '',
+  showIcon = true,
+  children,
+  onClick,
+}) {
+  const handleClick = (event) => {
+    // Skip analytics for right-click, middle-click, or modifier clicks —
+    // those open in new tab / copy link, not a primary WhatsApp intent.
+    const isPrimaryClick =
+      event.button === 0 && !event.ctrlKey && !event.metaKey && !event.shiftKey && !event.altKey
+    if (isPrimaryClick) {
+      track('WhatsApp Click', {
+        source: source || 'unknown',
+        path: typeof window !== 'undefined' ? window.location.pathname : '',
+      })
+    }
+    if (onClick) onClick(event)
+  }
+
+  return (
+    <Button
+      asChild
+      variant={variant}
+      size={size}
+      className={className}
+      onClick={handleClick}
+    >
+      <a
+        href={buildWhatsAppUrl({ message })}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {showIcon && <MessageCircle className="h-4 w-4" />}
+        {children ?? label}
+      </a>
+    </Button>
+  )
+}

--- a/src/components/therapist-finder/FilterBar.jsx
+++ b/src/components/therapist-finder/FilterBar.jsx
@@ -1,0 +1,171 @@
+import { useEffect, useState } from 'react'
+import { Input } from '@/components/ui/input.jsx'
+import { Button } from '@/components/ui/button.jsx'
+import { X, Video, MapPin, Filter as FilterIcon } from 'lucide-react'
+import therapistService from '../../services/therapistService'
+
+const GENDER_OPTIONS = [
+  { value: 'female', label: 'Feminino' },
+  { value: 'male', label: 'Masculino' },
+]
+
+const AUDIENCE_OPTIONS = [
+  { value: 'children', label: 'Crianças' },
+  { value: 'teens', label: 'Adolescentes' },
+  { value: 'adults', label: 'Adultos' },
+]
+
+const MODALITY_OPTIONS = [
+  { value: 'remote', label: 'Online', icon: Video },
+  { value: 'presencial', label: 'Presencial', icon: MapPin },
+]
+
+const RADIUS_OPTIONS = [3, 5, 10, 20]
+
+function Chip({ active, onClick, children, title }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      className={
+        "px-3 py-1.5 rounded-full text-sm border transition-colors " +
+        (active
+          ? "bg-blue-600 text-white border-blue-600"
+          : "bg-white text-gray-700 border-gray-300 hover:border-gray-500")
+      }
+    >
+      {children}
+    </button>
+  )
+}
+
+export default function FilterBar({ filters, onChange, onClear, totalCount }) {
+  const [availableThemes, setAvailableThemes] = useState([])
+
+  useEffect(() => {
+    let cancelled = false
+    therapistService.getPublicThemes()
+      .then(themes => { if (!cancelled) setAvailableThemes(themes) })
+      .catch(() => {})
+    return () => { cancelled = true }
+  }, [])
+
+  const setField = (key, value) => onChange({ ...filters, [key]: value })
+  const toggleField = (key, value) => {
+    const next = filters[key] === value ? null : value
+    onChange({ ...filters, [key]: next })
+  }
+  const toggleTheme = (id) => {
+    const current = filters.theme_ids || []
+    const next = current.includes(id) ? current.filter(x => x !== id) : [...current, id]
+    onChange({ ...filters, theme_ids: next })
+  }
+
+  const hasAnyFilter = Object.entries(filters).some(([k, v]) => {
+    if (k === 'theme_ids' || k === 'tag_ids') return Array.isArray(v) && v.length > 0
+    if (k === 'radius_km') return false
+    return v != null && v !== ''
+  })
+
+  return (
+    <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-4 sm:p-5 mb-6">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2 text-sm text-gray-700">
+          <FilterIcon className="h-4 w-4" />
+          <span className="font-semibold">Filtros</span>
+          {totalCount != null && (
+            <span className="text-gray-500">· {totalCount} {totalCount === 1 ? 'resultado' : 'resultados'}</span>
+          )}
+        </div>
+        {hasAnyFilter && (
+          <Button variant="ghost" size="sm" onClick={onClear} className="text-gray-500 hover:text-gray-700">
+            <X className="h-3 w-3 mr-1" />
+            Limpar filtros
+          </Button>
+        )}
+      </div>
+
+      <div className="space-y-4">
+        <FilterRow label="Gênero do profissional">
+          {GENDER_OPTIONS.map(opt => (
+            <Chip key={opt.value} active={filters.gender === opt.value} onClick={() => toggleField('gender', opt.value)}>
+              {opt.label}
+            </Chip>
+          ))}
+        </FilterRow>
+
+        <FilterRow label="Atende">
+          {AUDIENCE_OPTIONS.map(opt => (
+            <Chip key={opt.value} active={filters.audience === opt.value} onClick={() => toggleField('audience', opt.value)}>
+              {opt.label}
+            </Chip>
+          ))}
+        </FilterRow>
+
+        <FilterRow label="Modalidade">
+          {MODALITY_OPTIONS.map(opt => {
+            const Icon = opt.icon
+            return (
+              <Chip key={opt.value} active={filters.modality === opt.value} onClick={() => toggleField('modality', opt.value)}>
+                <span className="inline-flex items-center gap-1">
+                  <Icon className="h-3.5 w-3.5" />
+                  {opt.label}
+                </span>
+              </Chip>
+            )
+          })}
+        </FilterRow>
+
+        {filters.modality === 'presencial' && (
+          <FilterRow label="Proximidade">
+            <div className="flex flex-wrap items-center gap-2">
+              <Input
+                value={filters.cep || ''}
+                onChange={e => setField('cep', e.target.value)}
+                placeholder="Seu CEP"
+                className="w-32"
+                maxLength={9}
+              />
+              <div className="flex gap-1">
+                {RADIUS_OPTIONS.map(km => (
+                  <Chip
+                    key={km}
+                    active={(filters.radius_km || 5) === km}
+                    onClick={() => setField('radius_km', km)}
+                  >
+                    {km} km
+                  </Chip>
+                ))}
+              </div>
+            </div>
+          </FilterRow>
+        )}
+
+        {availableThemes.length > 0 && (
+          <FilterRow label="O que te trouxe aqui">
+            {availableThemes.map(theme => (
+              <Chip
+                key={theme.id}
+                active={(filters.theme_ids || []).includes(theme.id)}
+                onClick={() => toggleTheme(theme.id)}
+                title={theme.description || undefined}
+              >
+                {theme.name}
+              </Chip>
+            ))}
+          </FilterRow>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function FilterRow({ label, children }) {
+  return (
+    <div>
+      <p className="text-xs uppercase tracking-wider text-gray-500 font-semibold mb-2">{label}</p>
+      <div className="flex flex-wrap gap-2">{children}</div>
+    </div>
+  )
+}

--- a/src/components/therapist-finder/PromptTiles.jsx
+++ b/src/components/therapist-finder/PromptTiles.jsx
@@ -1,0 +1,78 @@
+import { User, Baby, Video, MapPin, Users } from 'lucide-react'
+
+const TILES = [
+  {
+    key: 'self_adult',
+    label: 'Terapia para mim',
+    caption: 'Adulto buscando cuidado',
+    icon: User,
+    filters: { audience: 'adults' },
+  },
+  {
+    key: 'child',
+    label: 'Para uma criança',
+    caption: 'Psicologia infantil',
+    icon: Baby,
+    filters: { audience: 'children' },
+  },
+  {
+    key: 'online',
+    label: 'Atendimento online',
+    caption: 'Terapia remota',
+    icon: Video,
+    filters: { modality: 'remote', audience: 'adults' },
+  },
+  {
+    key: 'presencial_sp',
+    label: 'Presencial em São Paulo',
+    caption: 'Sessões no meu bairro',
+    icon: MapPin,
+    filters: { modality: 'presencial', audience: 'adults' },
+  },
+]
+
+export default function PromptTiles({ onSelect, onSeeAll }) {
+  return (
+    <div className="max-w-4xl mx-auto">
+      <div className="text-center mb-8">
+        <h2 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-3">
+          O que você está procurando?
+        </h2>
+        <p className="text-gray-600">
+          Começa por aqui — a gente afina o resultado com você.
+        </p>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {TILES.map(tile => {
+          const Icon = tile.icon
+          return (
+            <button
+              key={tile.key}
+              type="button"
+              onClick={() => onSelect(tile.filters, tile.key)}
+              className="group flex items-center gap-4 p-5 rounded-xl border border-gray-200 bg-white hover:border-blue-500 hover:shadow-md transition-all text-left"
+            >
+              <div className="w-12 h-12 rounded-full bg-blue-50 group-hover:bg-blue-100 flex items-center justify-center flex-shrink-0 transition-colors">
+                <Icon className="h-6 w-6 text-blue-600" />
+              </div>
+              <div className="min-w-0">
+                <p className="font-semibold text-gray-900">{tile.label}</p>
+                <p className="text-sm text-gray-500">{tile.caption}</p>
+              </div>
+            </button>
+          )
+        })}
+      </div>
+      <div className="text-center mt-8">
+        <button
+          type="button"
+          onClick={onSeeAll}
+          className="text-sm text-gray-500 hover:text-gray-700 underline underline-offset-4"
+        >
+          <Users className="h-4 w-4 inline mr-1" />
+          Ver todos os psicólogos
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/therapist-finder/TherapistCard.jsx
+++ b/src/components/therapist-finder/TherapistCard.jsx
@@ -1,0 +1,187 @@
+import { useNavigate } from 'react-router-dom'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card.jsx'
+import { Button } from '@/components/ui/button.jsx'
+import { Badge } from '@/components/ui/badge.jsx'
+import { Star, User, ExternalLink, Brain, Clock, LogIn, Video, MapPin } from 'lucide-react'
+import authService from '../../services/authService'
+import { track } from '../../services/analytics'
+
+function getLowestPrice(therapist) {
+  if (!therapist.services || therapist.services.length === 0) return null
+  const prices = therapist.services.map(s => parseFloat(s.price)).filter(n => !Number.isNaN(n))
+  if (prices.length === 0) return null
+  return Math.min(...prices)
+}
+
+function ModalityBadges({ modalities }) {
+  if (!modalities) return null
+  const remote = !!modalities.remote
+  const presencial = !!modalities.presencial
+  if (!remote && !presencial) return null
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {remote && (
+        <Badge variant="outline" className="text-xs border-blue-200 text-blue-700 bg-blue-50">
+          <Video className="h-3 w-3 mr-1" />
+          Online
+        </Badge>
+      )}
+      {presencial && (
+        <Badge variant="outline" className="text-xs border-emerald-200 text-emerald-700 bg-emerald-50">
+          <MapPin className="h-3 w-3 mr-1" />
+          Presencial
+        </Badge>
+      )}
+    </div>
+  )
+}
+
+function OfficesLine({ offices, nearestOffice }) {
+  const activeOffices = (offices || []).filter(o => o && (o.active !== false))
+  if (activeOffices.length === 0) return null
+
+  // When a CEP filter is applied, backend surfaces the nearest office with distance.
+  if (nearestOffice && nearestOffice.distance_km != null) {
+    const label = nearestOffice.label || nearestOffice.neighborhood || 'Local'
+    const extraCount = activeOffices.length - 1
+    return (
+      <p className="text-xs text-gray-500 flex items-center gap-1 flex-wrap">
+        <MapPin className="h-3 w-3 flex-shrink-0" />
+        {activeOffices.length > 1 && (
+          <span className="font-medium text-gray-700">{activeOffices.length} locais · </span>
+        )}
+        <span>mais próximo: {label}</span>
+        <span className="text-gray-400">· {nearestOffice.distance_km.toFixed(1)} km</span>
+        {extraCount > 0 && (
+          <span className="text-gray-400">(+{extraCount} {extraCount === 1 ? 'outro' : 'outros'})</span>
+        )}
+      </p>
+    )
+  }
+
+  // No CEP filter: list up to 3 office labels
+  const labels = activeOffices
+    .slice(0, 3)
+    .map(o => o.label || o.neighborhood)
+    .filter(Boolean)
+  if (labels.length === 0) return null
+  const extra = activeOffices.length - labels.length
+  return (
+    <p className="text-xs text-gray-500 flex items-center gap-1 flex-wrap">
+      <MapPin className="h-3 w-3 flex-shrink-0" />
+      {labels.join(' · ')}
+      {extra > 0 && <span className="text-gray-400">+{extra}</span>}
+    </p>
+  )
+}
+
+export default function TherapistCard({ therapist, index }) {
+  const navigate = useNavigate()
+  const loggedIn = authService.isLoggedIn()
+  const lowestPrice = getLowestPrice(therapist)
+
+  const handleScheduleClick = () => {
+    track('Therapist Card Click', {
+      therapist_id: therapist.id,
+      position: index ?? 0,
+      path: window.location.pathname,
+    })
+    if (loggedIn) {
+      navigate('/scheduling', { state: { therapistId: therapist.id } })
+    } else {
+      navigate('/form')
+    }
+  }
+
+  return (
+    <Card className="hover:shadow-lg transition-shadow flex flex-col h-full">
+      <CardHeader>
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex items-center space-x-3 min-w-0">
+            {therapist.image && therapist.image !== '👨‍⚕️' ? (
+              <img
+                src={therapist.image}
+                alt={therapist.name}
+                className="w-12 h-12 rounded-full object-cover flex-shrink-0"
+              />
+            ) : (
+              <div className="w-12 h-12 rounded-full bg-purple-100 flex items-center justify-center flex-shrink-0">
+                <Brain className="h-7 w-7 text-purple-600" />
+              </div>
+            )}
+            <div className="min-w-0">
+              <CardTitle className="text-lg truncate">{therapist.name}</CardTitle>
+              <CardDescription className="truncate">{therapist.specialty}</CardDescription>
+            </div>
+          </div>
+          <Badge variant="secondary" className="ml-2 flex-shrink-0">
+            <Star className="h-3 w-3 mr-1 fill-yellow-400 text-yellow-400" />
+            {therapist.rating}
+          </Badge>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-3 flex-1 flex flex-col">
+        <ModalityBadges modalities={therapist.modalities} />
+        <OfficesLine offices={therapist.offices} nearestOffice={therapist.nearestOffice} />
+
+        <div className="flex items-center justify-between text-sm">
+          <div className="flex items-center text-gray-600">
+            <User className="h-4 w-4 mr-1" />
+            <span>{therapist.experience}</span>
+          </div>
+          {lowestPrice != null && (
+            <div className="flex items-center text-green-600 font-medium">
+              <span>a partir de R$ {lowestPrice.toFixed(0)}</span>
+            </div>
+          )}
+        </div>
+
+        {therapist.tags && therapist.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {therapist.tags.slice(0, 4).map(tag => (
+              <span key={tag.id} className="text-[10px] px-2 py-0.5 rounded-full bg-gray-100 text-gray-600">
+                {tag.name}
+              </span>
+            ))}
+            {therapist.tags.length > 4 && (
+              <span className="text-[10px] text-gray-400 px-1">+{therapist.tags.length - 4}</span>
+            )}
+          </div>
+        )}
+
+        {therapist.bio && (
+          <p
+            className="text-sm text-gray-600 line-clamp-4 cursor-pointer"
+            onClick={(e) => e.currentTarget.classList.toggle('line-clamp-4')}
+          >
+            {therapist.bio}
+          </p>
+        )}
+
+        {therapist.crpNumber && (
+          <div className="text-xs text-gray-500 text-center py-2 border-t">
+            CRP: {therapist.crpNumber}
+          </div>
+        )}
+
+        <div className="space-y-2 pt-2 mt-auto">
+          <Button className="w-full" onClick={handleScheduleClick}>
+            {loggedIn ? <Clock className="h-4 w-4 mr-2" /> : <LogIn className="h-4 w-4 mr-2" />}
+            Agendar Sessão
+          </Button>
+          {therapist.personalSiteUrl && (
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={() => window.open(therapist.personalSiteUrl, '_blank')}
+            >
+              <ExternalLink className="h-4 w-4 mr-2" />
+              Ver Site
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/therapist-finder/TherapistFinder.jsx
+++ b/src/components/therapist-finder/TherapistFinder.jsx
@@ -1,0 +1,267 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Loader2, ChevronLeft, ChevronRight, Users } from 'lucide-react'
+import { Button } from '@/components/ui/button.jsx'
+import therapistService from '../../services/therapistService'
+import { track } from '../../services/analytics'
+import WhatsAppButton from '../WhatsAppButton.jsx'
+import PromptTiles from './PromptTiles.jsx'
+import FilterBar from './FilterBar.jsx'
+import TherapistCard from './TherapistCard.jsx'
+
+const EMPTY_FILTERS = {
+  gender: null,
+  audience: null,
+  modality: null,
+  theme_ids: [],
+  cep: '',
+  radius_km: 5,
+}
+
+function cleanFilters(filters) {
+  const out = {}
+  if (filters.gender) out.gender = filters.gender
+  if (filters.audience) out.audience = filters.audience
+  if (filters.modality) out.modality = filters.modality
+  if (filters.theme_ids && filters.theme_ids.length) out.theme_ids = filters.theme_ids
+  if (filters.modality === 'presencial' && filters.cep && /^\d{8}$/.test(filters.cep.replace(/\D/g, ''))) {
+    out.cep = filters.cep
+    out.radius_km = filters.radius_km || 5
+  }
+  return out
+}
+
+export default function TherapistFinder({
+  initialFilters = EMPTY_FILTERS,
+  showPrompt = true,
+  priorityTherapistId = null,
+  heading = 'Nossos Psicólogos',
+  subheading = 'Conheça nossa equipe de profissionais',
+  initialDisplay = null,   // if set, show only first N until user clicks "Ver todos"
+  pageSize = 6,
+}) {
+  const [mode, setMode] = useState(showPrompt ? 'prompt' : 'results')
+  const [filters, setFilters] = useState({ ...EMPTY_FILTERS, ...initialFilters })
+  const [therapists, setTherapists] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const [showAll, setShowAll] = useState(!initialDisplay)
+  const [page, setPage] = useState(1)
+  const debounceRef = useRef(null)
+  const lastFilterKeyRef = useRef('')
+  const fetchSeqRef = useRef(0)
+
+  const effectiveFilters = useMemo(() => cleanFilters(filters), [filters])
+  const filterKey = useMemo(() => JSON.stringify(effectiveFilters), [effectiveFilters])
+
+  useEffect(() => {
+    if (mode !== 'results') return
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      const mySeq = ++fetchSeqRef.current
+      fetchTherapists(effectiveFilters, filterKey, mySeq)
+    }, 200)
+    return () => { if (debounceRef.current) clearTimeout(debounceRef.current) }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filterKey, mode])
+
+  // Reset pagination whenever filters change
+  useEffect(() => {
+    setPage(1)
+  }, [filterKey])
+
+  async function fetchTherapists(appliedFilters, capturedFilterKey, mySeq) {
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await therapistService.getFilteredTherapists(appliedFilters)
+      // Discard results from superseded fetches — the user changed filters mid-flight.
+      if (mySeq !== fetchSeqRef.current) return
+      let formatted = therapistService.formatTherapistsForUI(data)
+
+      if (priorityTherapistId) {
+        const idx = formatted.findIndex(t => t.id === priorityTherapistId)
+        if (idx > 0) {
+          const [priority] = formatted.splice(idx, 1)
+          formatted.unshift(priority)
+        }
+      }
+
+      setTherapists(formatted)
+
+      if (Object.keys(appliedFilters).length > 0 && capturedFilterKey !== lastFilterKeyRef.current) {
+        track('Filter Applied', {
+          ...appliedFilters,
+          theme_count: appliedFilters.theme_ids ? appliedFilters.theme_ids.length : 0,
+          result_count: formatted.length,
+          path: window.location.pathname,
+        })
+        lastFilterKeyRef.current = capturedFilterKey
+      }
+
+      if (formatted.length === 0 && Object.keys(appliedFilters).length > 0) {
+        track('Empty Results', {
+          ...appliedFilters,
+          theme_count: appliedFilters.theme_ids ? appliedFilters.theme_ids.length : 0,
+          path: window.location.pathname,
+        })
+      }
+    } catch (err) {
+      if (mySeq !== fetchSeqRef.current) return
+      console.error('Failed to fetch therapists:', err)
+      setError(err?.errors?.[0] || 'Não foi possível carregar os psicólogos. Tente novamente em instantes.')
+      setTherapists([])
+    } finally {
+      if (mySeq === fetchSeqRef.current) {
+        setLoading(false)
+      }
+    }
+  }
+
+  const handlePromptSelect = (prefilled, tileKey) => {
+    track('Prompt Tile Click', { tile: tileKey, path: window.location.pathname })
+    setFilters({ ...EMPTY_FILTERS, ...prefilled })
+    setMode('results')
+  }
+
+  const handleSeeAll = () => {
+    track('Prompt Tile Click', { tile: 'see_all', path: window.location.pathname })
+    setFilters(EMPTY_FILTERS)
+    setMode('results')
+  }
+
+  const handleClear = () => {
+    setFilters(EMPTY_FILTERS)
+    lastFilterKeyRef.current = ''
+  }
+
+  const handleSeeAllResults = () => {
+    track('See All Therapists Click', { total: therapists.length, path: window.location.pathname })
+    setShowAll(true)
+    setPage(1)
+  }
+
+  const totalResults = therapists.length
+  const useInitialCap = !!initialDisplay && !showAll
+  const totalPages = Math.max(1, Math.ceil(totalResults / pageSize))
+  const currentPage = Math.min(page, totalPages)
+
+  let visibleTherapists
+  if (useInitialCap) {
+    visibleTherapists = therapists.slice(0, initialDisplay)
+  } else {
+    visibleTherapists = therapists.slice((currentPage - 1) * pageSize, currentPage * pageSize)
+  }
+
+  if (mode === 'prompt') {
+    return (
+      <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+        <PromptTiles onSelect={handlePromptSelect} onSeeAll={handleSeeAll} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+      {(heading || subheading) && (
+        <div className="mb-6">
+          {heading && <h2 className="text-3xl font-bold text-gray-900 mb-1">{heading}</h2>}
+          {subheading && <p className="text-gray-600">{subheading}</p>}
+        </div>
+      )}
+
+      <FilterBar
+        filters={filters}
+        onChange={setFilters}
+        onClear={handleClear}
+        totalCount={loading ? null : therapists.length}
+      />
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-4">
+          <p className="text-red-800 text-sm">{error}</p>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex justify-center items-center py-16">
+          <Loader2 className="h-8 w-8 animate-spin text-blue-600" />
+        </div>
+      ) : therapists.length === 0 ? (
+        <EmptyState hasFilters={Object.keys(effectiveFilters).length > 0} onClear={handleClear} />
+      ) : (
+        <>
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {visibleTherapists.map((therapist, idx) => (
+              <TherapistCard key={therapist.id} therapist={therapist} index={(useInitialCap ? 0 : (currentPage - 1) * pageSize) + idx} />
+            ))}
+          </div>
+
+          {useInitialCap && totalResults > initialDisplay && (
+            <div className="mt-8 text-center">
+              <Button variant="outline" size="lg" onClick={handleSeeAllResults}>
+                <Users className="h-4 w-4 mr-2" />
+                Ver todos os {totalResults} psicólogos
+              </Button>
+            </div>
+          )}
+
+          {!useInitialCap && totalPages > 1 && (
+            <div className="mt-8 flex items-center justify-center gap-3">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={currentPage === 1}
+                onClick={() => setPage(p => Math.max(1, p - 1))}
+              >
+                <ChevronLeft className="h-4 w-4" />
+                Anterior
+              </Button>
+              <span className="text-sm text-gray-600">
+                Página <span className="font-semibold text-gray-900">{currentPage}</span> de {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={currentPage >= totalPages}
+                onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+              >
+                Próxima
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+function EmptyState({ hasFilters, onClear }) {
+  return (
+    <div className="text-center py-14 px-4 rounded-2xl border border-dashed border-gray-200 bg-gray-50">
+      <p className="text-lg font-semibold text-gray-900 mb-1">Nenhum psicólogo encontrado</p>
+      <p className="text-sm text-gray-500 mb-5">
+        {hasFilters
+          ? 'Tente relaxar um filtro ou fale com a gente no WhatsApp — ajudamos você a encontrar quem combina.'
+          : 'Ainda estamos preparando a lista. Volte em instantes.'}
+      </p>
+      <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+        {hasFilters && (
+          <button
+            type="button"
+            onClick={onClear}
+            className="text-sm text-gray-600 hover:text-gray-900 underline underline-offset-4"
+          >
+            Limpar filtros
+          </button>
+        )}
+        <WhatsAppButton
+          source="empty_results"
+          label="Falar no WhatsApp"
+          message="Oi, usei os filtros no site e não encontrei um psicólogo que encaixa. Pode me ajudar a escolher?"
+          variant="outline"
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/pages/AcolhimentoLandingPage.jsx
+++ b/src/pages/AcolhimentoLandingPage.jsx
@@ -7,6 +7,8 @@ import { useParams } from 'react-router-dom'
 import therapistService from '../services/therapistService'
 import SEOHead from '../components/SEOHead'
 import horizontalLogo from '../assets/horizontal-logo.png'
+import { openWhatsApp } from '../utils/whatsapp'
+import { track } from '../services/analytics'
 
 export default function AcolhimentoLandingPage() {
   const { slug } = useParams()
@@ -42,17 +44,19 @@ export default function AcolhimentoLandingPage() {
   }, [slug])
 
   const handleWhatsAppClick = () => {
-    const phoneNumber = '5511914214449'
     let message
     if (therapist) {
       const priceRef = therapist.acolhimento_price ? `R$${therapist.acolhimento_price}` : ''
-      message = encodeURIComponent(
-        `Olá, vi a página da ${therapist.name} e gostaria de saber mais sobre a Sessão de Acolhimento. [ref: ${slug || 'acolhimento'}/${priceRef}]`
-      )
+      message = `Olá, vi a página da ${therapist.name} e gostaria de saber mais sobre a Sessão de Acolhimento. [ref: ${slug || 'acolhimento'}/${priceRef}]`
     } else {
-      message = encodeURIComponent('Olá, gostaria de saber mais sobre a Sessão de Acolhimento.')
+      message = 'Olá, gostaria de saber mais sobre a Sessão de Acolhimento.'
     }
-    window.open(`https://wa.me/${phoneNumber}?text=${message}`, '_blank')
+    track('WhatsApp Click', {
+      source: 'acolhimento',
+      path: window.location.pathname,
+      has_therapist: !!therapist,
+    })
+    openWhatsApp({ message })
   }
 
   if (loading) {

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 import {
   Building2, Users, UserCog, Plus, Search, Edit, Power, Loader2,
-  Shield, X, UserPlus, Upload, Trash2, Mail, MessageSquare, Eye, Briefcase, ClipboardList
+  Shield, X, UserPlus, Upload, Trash2, Mail, MessageSquare, Eye, Briefcase, ClipboardList, Tag as TagIcon
 } from 'lucide-react'
 
 import { Button } from '@/components/ui/button.jsx'
@@ -101,6 +101,10 @@ export default function AdminPage() {
               <ClipboardList className="h-4 w-4" />
               Questionários
             </TabsTrigger>
+            <TabsTrigger value="themes" className="gap-1.5">
+              <TagIcon className="h-4 w-4" />
+              Temas
+            </TabsTrigger>
           </TabsList>
 
           <TabsContent value="companies">
@@ -120,6 +124,9 @@ export default function AdminPage() {
           </TabsContent>
           <TabsContent value="questionnaires">
             <QuestionnairesTab />
+          </TabsContent>
+          <TabsContent value="themes">
+            <ThemesTab />
           </TabsContent>
         </Tabs>
       </div>
@@ -927,9 +934,24 @@ function CompanyDetailDialog({ open, onOpenChange, company, onUpdate }) {
 function TherapistFormDialog({ open, onOpenChange, therapist, onSave }) {
   const [form, setForm] = useState({})
   const [saving, setSaving] = useState(false)
+  const [availableTags, setAvailableTags] = useState([])
 
   useEffect(() => {
     if (open) {
+      const mapOffice = (o) => ({
+        id: o.id,
+        label: o.label || '',
+        cep: o.cep || '',
+        street: o.street || '',
+        neighborhood: o.neighborhood || '',
+        city: o.city || 'São Paulo',
+        state: o.state || 'SP',
+        active: o.active !== false,
+        position: o.position ?? 0,
+        location_geocoded_at: o.location_geocoded_at,
+        _destroy: false,
+      })
+
       setForm(therapist ? {
         email: therapist.email || '',
         name: therapist.name || '',
@@ -943,19 +965,84 @@ function TherapistFormDialog({ open, onOpenChange, therapist, onSave }) {
         acolhimento_price: therapist.acolhimento_price || '',
         acolhimento_quote: therapist.acolhimento_quote || '',
         position: therapist.position ?? 0,
+        gender: therapist.gender || '',
+        pronouns: therapist.pronouns || '',
+        serves_children: !!therapist.serves_children,
+        serves_teens: !!therapist.serves_teens,
+        serves_adults: therapist.serves_adults ?? true,
+        offers_remote: therapist.offers_remote ?? true,
+        offers_presencial: !!therapist.offers_presencial,
+        offices: Array.isArray(therapist.offices) ? therapist.offices.map(mapOffice) : [],
+        tag_ids: Array.isArray(therapist.tag_ids) ? therapist.tag_ids : [],
         password: '',
         password_confirmation: '',
       } : {
         email: '', name: '', specialty: '', experience_years: '', bio: '',
         crp_number: '', credits_per_minute: '', personal_site_url: '', calendly_url: '',
         acolhimento_price: '', acolhimento_quote: '', position: 0,
+        gender: '', pronouns: '',
+        serves_children: false, serves_teens: false, serves_adults: true,
+        offers_remote: true, offers_presencial: false,
+        offices: [],
+        tag_ids: [],
         password: '', password_confirmation: '',
       })
     }
   }, [open, therapist])
 
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    adminService.getTags()
+      .then(tags => { if (!cancelled) setAvailableTags(tags) })
+      .catch(() => { if (!cancelled) setAvailableTags([]) })
+    return () => { cancelled = true }
+  }, [open])
+
   const handleChange = (e) => {
-    setForm(prev => ({ ...prev, [e.target.name]: e.target.value }))
+    const { name, type, value, checked } = e.target
+    setForm(prev => ({ ...prev, [name]: type === 'checkbox' ? checked : value }))
+  }
+
+  const toggleTagId = (id) => {
+    setForm(prev => {
+      const current = prev.tag_ids || []
+      const next = current.includes(id)
+        ? current.filter(x => x !== id)
+        : [...current, id]
+      return { ...prev, tag_ids: next }
+    })
+  }
+
+  const addOffice = () => {
+    setForm(prev => ({
+      ...prev,
+      offices: [
+        ...(prev.offices || []),
+        { id: null, label: '', cep: '', street: '', neighborhood: '', city: 'São Paulo', state: 'SP', active: true, position: (prev.offices || []).length, _destroy: false },
+      ],
+    }))
+  }
+
+  const updateOffice = (idx, key, value) => {
+    setForm(prev => {
+      const next = [...(prev.offices || [])]
+      next[idx] = { ...next[idx], [key]: value }
+      return { ...prev, offices: next }
+    })
+  }
+
+  const removeOffice = (idx) => {
+    setForm(prev => {
+      const next = [...(prev.offices || [])]
+      const item = next[idx]
+      if (item?.id) {
+        next[idx] = { ...item, _destroy: true }
+      } else {
+        next.splice(idx, 1)
+      }
+      return { ...prev, offices: next }
+    })
   }
 
   const handleSubmit = async (e) => {
@@ -967,15 +1054,47 @@ function TherapistFormDialog({ open, onOpenChange, therapist, onSave }) {
       toast.error('Senhas não conferem'); return
     }
 
+    const offices = form.offices || []
+    for (const o of offices) {
+      if (o._destroy) continue
+      if (o.cep && !/^\d{8}$/.test(o.cep.replace(/\D/g, ''))) {
+        toast.error(`CEP inválido em "${o.label || 'localização sem nome'}" — deve ter 8 dígitos`); return
+      }
+    }
+
     setSaving(true)
-    const data = { ...form }
-    if (data.experience_years) data.experience_years = parseInt(data.experience_years)
-    if (data.credits_per_minute) data.credits_per_minute = parseFloat(data.credits_per_minute)
-    if (data.acolhimento_price) data.acolhimento_price = parseFloat(data.acolhimento_price)
-    if (!data.acolhimento_price) delete data.acolhimento_price
-    if (!data.password) { delete data.password; delete data.password_confirmation }
-    await onSave(data)
-    setSaving(false)
+    try {
+      const data = { ...form }
+      if (data.experience_years) data.experience_years = parseInt(data.experience_years)
+      if (data.credits_per_minute) data.credits_per_minute = parseFloat(data.credits_per_minute)
+      if (data.acolhimento_price) data.acolhimento_price = parseFloat(data.acolhimento_price)
+      if (!data.acolhimento_price) delete data.acolhimento_price
+      if (!data.password) { delete data.password; delete data.password_confirmation }
+      if (!data.gender) delete data.gender
+
+      data.therapist_offices_attributes = offices
+        .filter(o => !(o._destroy && !o.id))
+        .map(o => {
+          const attrs = {
+            label: o.label || null,
+            cep: o.cep ? o.cep.replace(/\D/g, '') : null,
+            street: o.street || null,
+            neighborhood: o.neighborhood || null,
+            city: o.city || null,
+            state: o.state || null,
+            active: !!o.active,
+            position: o.position ?? 0,
+          }
+          if (o.id) attrs.id = o.id
+          if (o._destroy) attrs._destroy = '1'
+          return attrs
+        })
+      delete data.offices
+
+      await onSave(data)
+    } finally {
+      setSaving(false)
+    }
   }
 
   return (
@@ -1053,6 +1172,211 @@ function TherapistFormDialog({ open, onOpenChange, therapist, onSave }) {
               <Input id="therapist-calendly" name="calendly_url" type="url" value={form.calendly_url || ''} onChange={handleChange} />
             </div>
           </div>
+
+          {/* Demografia & Público */}
+          <div className="border-t pt-4">
+            <p className="text-sm font-medium mb-2">Demografia & Público</p>
+            <div className="grid grid-cols-2 gap-4 mb-3">
+              <div>
+                <Label>Gênero</Label>
+                <Select
+                  value={form.gender || '_unset'}
+                  onValueChange={val => setForm(prev => ({ ...prev, gender: val === '_unset' ? '' : val }))}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Não informado" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="_unset">Não informado</SelectItem>
+                    <SelectItem value="female">Feminino</SelectItem>
+                    <SelectItem value="male">Masculino</SelectItem>
+                    <SelectItem value="other">Outro</SelectItem>
+                    <SelectItem value="prefer_not_to_say">Prefere não dizer</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label htmlFor="therapist-pronouns">Pronomes</Label>
+                <Input id="therapist-pronouns" name="pronouns" value={form.pronouns || ''} onChange={handleChange} placeholder="ela/dela" />
+              </div>
+            </div>
+            <Label className="text-xs text-gray-600">Atende</Label>
+            <div className="flex flex-wrap gap-4 mt-1">
+              <label className="inline-flex items-center gap-2 text-sm">
+                <input type="checkbox" name="serves_children" checked={!!form.serves_children} onChange={handleChange} />
+                Crianças (0–12)
+              </label>
+              <label className="inline-flex items-center gap-2 text-sm">
+                <input type="checkbox" name="serves_teens" checked={!!form.serves_teens} onChange={handleChange} />
+                Adolescentes (13–17)
+              </label>
+              <label className="inline-flex items-center gap-2 text-sm">
+                <input type="checkbox" name="serves_adults" checked={!!form.serves_adults} onChange={handleChange} />
+                Adultos (18+)
+              </label>
+            </div>
+          </div>
+
+          {/* Modalidade */}
+          <div className="border-t pt-4">
+            <p className="text-sm font-medium mb-2">Modalidade</p>
+            <div className="flex flex-wrap gap-4">
+              <label className="inline-flex items-center gap-2 text-sm">
+                <input type="checkbox" name="offers_remote" checked={!!form.offers_remote} onChange={handleChange} />
+                Atende online (remoto)
+              </label>
+              <label className="inline-flex items-center gap-2 text-sm">
+                <input type="checkbox" name="offers_presencial" checked={!!form.offers_presencial} onChange={handleChange} />
+                Atende presencial
+              </label>
+            </div>
+          </div>
+
+          {/* Locais de atendimento presencial */}
+          {form.offers_presencial && (
+            <div className="border-t pt-4">
+              <div className="flex items-center justify-between mb-2">
+                <p className="text-sm font-medium">Locais de atendimento presencial</p>
+                <Button type="button" size="sm" variant="outline" onClick={addOffice}>
+                  <Plus className="h-3.5 w-3.5 mr-1" />
+                  Adicionar localização
+                </Button>
+              </div>
+              <p className="text-xs text-gray-500 mb-3">
+                Cada local tem seu próprio CEP. Ao salvar, endereço e coordenadas são preenchidos
+                automaticamente (ViaCEP + OpenStreetMap). O filtro de proximidade usa o local mais próximo.
+              </p>
+              {(form.offices || []).filter(o => !o._destroy).length === 0 ? (
+                <p className="text-xs text-gray-400 italic">Nenhuma localização adicionada ainda.</p>
+              ) : (
+                <div className="space-y-3">
+                  {(form.offices || []).map((office, idx) => {
+                    if (office._destroy) return null
+                    return (
+                      <div key={idx} className="border rounded-lg p-3 bg-gray-50">
+                        <div className="flex items-start gap-2 mb-2">
+                          <div className="flex-1">
+                            <Label className="text-xs">Identificação</Label>
+                            <Input
+                              value={office.label || ''}
+                              onChange={e => updateOffice(idx, 'label', e.target.value)}
+                              placeholder="Ex: Pinheiros, Angélica, Paulista"
+                              className="bg-white"
+                            />
+                          </div>
+                          <div className="flex items-center gap-3 pt-6">
+                            <label className="inline-flex items-center gap-1 text-xs whitespace-nowrap">
+                              <input
+                                type="checkbox"
+                                checked={!!office.active}
+                                onChange={e => updateOffice(idx, 'active', e.target.checked)}
+                              />
+                              Ativo
+                            </label>
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="ghost"
+                              onClick={() => removeOffice(idx)}
+                              className="text-red-500 hover:text-red-700 px-2"
+                            >
+                              <X className="h-4 w-4" />
+                            </Button>
+                          </div>
+                        </div>
+                        <div className="grid grid-cols-3 gap-2 mb-2">
+                          <div>
+                            <Label className="text-xs">CEP</Label>
+                            <Input
+                              value={office.cep || ''}
+                              onChange={e => updateOffice(idx, 'cep', e.target.value)}
+                              placeholder="04038000"
+                              maxLength={9}
+                              className="bg-white"
+                            />
+                          </div>
+                          <div className="col-span-2">
+                            <Label className="text-xs">Rua</Label>
+                            <Input
+                              value={office.street || ''}
+                              onChange={e => updateOffice(idx, 'street', e.target.value)}
+                              placeholder="Preenchido pelo CEP"
+                              className="bg-white"
+                            />
+                          </div>
+                        </div>
+                        <div className="grid grid-cols-3 gap-2">
+                          <div>
+                            <Label className="text-xs">Bairro</Label>
+                            <Input
+                              value={office.neighborhood || ''}
+                              onChange={e => updateOffice(idx, 'neighborhood', e.target.value)}
+                              className="bg-white"
+                            />
+                          </div>
+                          <div>
+                            <Label className="text-xs">Cidade</Label>
+                            <Input
+                              value={office.city || ''}
+                              onChange={e => updateOffice(idx, 'city', e.target.value)}
+                              placeholder="São Paulo"
+                              className="bg-white"
+                            />
+                          </div>
+                          <div>
+                            <Label className="text-xs">UF</Label>
+                            <Input
+                              value={office.state || ''}
+                              onChange={e => updateOffice(idx, 'state', e.target.value)}
+                              maxLength={2}
+                              placeholder="SP"
+                              className="bg-white"
+                            />
+                          </div>
+                        </div>
+                        {office.location_geocoded_at && (
+                          <p className="text-xs text-gray-500 mt-2">
+                            Geocodificado em: {new Date(office.location_geocoded_at).toLocaleString('pt-BR')}
+                          </p>
+                        )}
+                      </div>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Tags / Temas */}
+          <div className="border-t pt-4">
+            <p className="text-sm font-medium mb-1">Temas / Especializações</p>
+            <p className="text-xs text-gray-500 mb-3">Selecione as tags que aparecem no filtro de busca.</p>
+            {availableTags.length === 0 ? (
+              <p className="text-xs text-gray-400">Nenhuma tag cadastrada.</p>
+            ) : (
+              <div className="flex flex-wrap gap-1.5">
+                {availableTags.map(tag => {
+                  const selected = (form.tag_ids || []).includes(tag.id)
+                  return (
+                    <button
+                      type="button"
+                      key={tag.id}
+                      onClick={() => toggleTagId(tag.id)}
+                      className={
+                        "px-2.5 py-1 rounded-full text-xs border transition-colors " +
+                        (selected
+                          ? "bg-primary text-white border-primary"
+                          : "bg-white text-gray-700 border-gray-200 hover:border-gray-400")
+                      }
+                    >
+                      {tag.name}
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+
           <div className="border-t pt-4">
             <p className="text-sm font-medium mb-2">{therapist ? 'Alterar senha (opcional)' : 'Senha *'}</p>
             <div className="grid grid-cols-2 gap-4">
@@ -2124,5 +2448,330 @@ function QuestionnairesTab() {
         onConfirm={handleToggleActive}
       />
     </>
+  )
+}
+
+// ─── Themes Tab ──────────────────────────────────────────────
+
+function ThemesTab() {
+  const [themes, setThemes] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editing, setEditing] = useState(null)
+  const [toggleTarget, setToggleTarget] = useState(null)
+  const [deleteTarget, setDeleteTarget] = useState(null)
+
+  const loadThemes = async () => {
+    try {
+      const data = await adminService.getThemes()
+      setThemes(Array.isArray(data) ? data : [])
+    } catch (e) {
+      toast.error('Erro ao carregar temas')
+      console.error(e)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { loadThemes() }, [])
+
+  const handleNew = () => { setEditing(null); setDialogOpen(true) }
+  const handleEdit = (theme) => { setEditing(theme); setDialogOpen(true) }
+
+  const handleSave = async (data) => {
+    try {
+      if (editing) {
+        await adminService.updateTheme(editing.id, data)
+        toast.success('Tema atualizado')
+      } else {
+        await adminService.createTheme(data)
+        toast.success('Tema criado')
+      }
+      setDialogOpen(false)
+      loadThemes()
+    } catch (e) {
+      const msg = e.errors?.[0] || e.message || 'Erro ao salvar tema'
+      toast.error(msg)
+      console.error(e)
+    }
+  }
+
+  const handleToggleActive = async () => {
+    if (!toggleTarget) return
+    try {
+      await adminService.toggleThemeActive(toggleTarget.id)
+      toast.success(toggleTarget.active ? 'Tema desativado' : 'Tema ativado')
+      setToggleTarget(null)
+      loadThemes()
+    } catch (e) {
+      toast.error('Erro ao alternar status')
+      console.error(e)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return
+    try {
+      await adminService.deleteTheme(deleteTarget.id)
+      toast.success('Tema removido')
+      setDeleteTarget(null)
+      loadThemes()
+    } catch (e) {
+      toast.error('Erro ao remover tema')
+      console.error(e)
+    }
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>Temas de busca</CardTitle>
+              <p className="text-sm text-gray-500 mt-1">
+                Temas aparecem no filtro da home. Cada tema agrupa várias tags — o paciente vê poucos temas, o terapeuta usa tags granulares.
+              </p>
+            </div>
+            <Button onClick={handleNew} size="sm">
+              <Plus className="h-4 w-4 mr-1" />
+              Novo tema
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+            </div>
+          ) : themes.length === 0 ? (
+            <div className="text-center py-8 text-gray-500 text-sm">
+              Nenhum tema cadastrado. Rode <code className="bg-gray-100 px-1 rounded">rake themes:seed</code> para criar os 8 iniciais, ou clique em "Novo tema".
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-16">Ordem</TableHead>
+                  <TableHead>Nome</TableHead>
+                  <TableHead>Tags</TableHead>
+                  <TableHead className="w-24">Status</TableHead>
+                  <TableHead className="w-36 text-right">Ações</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {themes.map(theme => (
+                  <TableRow key={theme.id}>
+                    <TableCell className="font-mono text-xs">{theme.display_order}</TableCell>
+                    <TableCell>
+                      <div className="font-medium">{theme.name}</div>
+                      {theme.description && (
+                        <div className="text-xs text-gray-500 line-clamp-2">{theme.description}</div>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-wrap gap-1">
+                        {(theme.tags || []).slice(0, 5).map(tag => (
+                          <span key={tag.id} className="text-[10px] px-2 py-0.5 rounded-full bg-gray-100 text-gray-600">
+                            {tag.name}
+                          </span>
+                        ))}
+                        {(theme.tags || []).length > 5 && (
+                          <span className="text-[10px] text-gray-400 px-1">+{theme.tags.length - 5}</span>
+                        )}
+                        {(theme.tags || []).length === 0 && (
+                          <span className="text-xs text-gray-400 italic">sem tags</span>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={theme.active ? 'default' : 'secondary'}>
+                        {theme.active ? 'Ativo' : 'Inativo'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex items-center gap-1 justify-end">
+                        <Button size="sm" variant="ghost" onClick={() => handleEdit(theme)}>
+                          <Edit className="h-3.5 w-3.5" />
+                        </Button>
+                        <Button size="sm" variant="ghost" onClick={() => setToggleTarget(theme)}>
+                          <Power className="h-3.5 w-3.5" />
+                        </Button>
+                        <Button size="sm" variant="ghost" onClick={() => setDeleteTarget(theme)}>
+                          <Trash2 className="h-3.5 w-3.5 text-red-500" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <ThemeFormDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        theme={editing}
+        onSave={handleSave}
+      />
+
+      <ToggleActiveDialog
+        open={!!toggleTarget}
+        onOpenChange={(open) => !open && setToggleTarget(null)}
+        name={toggleTarget?.name}
+        active={toggleTarget?.active}
+        onConfirm={handleToggleActive}
+      />
+
+      <AlertDialog open={!!deleteTarget} onOpenChange={(open) => !open && setDeleteTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remover tema?</AlertDialogTitle>
+            <AlertDialogDescription>
+              O tema "{deleteTarget?.name}" será removido do filtro da home. As tags associadas não são afetadas.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete} className="bg-red-600 hover:bg-red-700">
+              Remover
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}
+
+// ─── Theme Form Dialog ───────────────────────────────────────
+
+function ThemeFormDialog({ open, onOpenChange, theme, onSave }) {
+  const [form, setForm] = useState({})
+  const [saving, setSaving] = useState(false)
+  const [availableTags, setAvailableTags] = useState([])
+
+  useEffect(() => {
+    if (open) {
+      setForm(theme ? {
+        name: theme.name || '',
+        description: theme.description || '',
+        display_order: theme.display_order ?? 0,
+        active: theme.active !== false,
+        tag_ids: Array.isArray(theme.tag_ids) ? theme.tag_ids : [],
+      } : {
+        name: '', description: '', display_order: 0, active: true, tag_ids: [],
+      })
+    }
+  }, [open, theme])
+
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    adminService.getTags()
+      .then(tags => { if (!cancelled) setAvailableTags(tags) })
+      .catch(() => { if (!cancelled) setAvailableTags([]) })
+    return () => { cancelled = true }
+  }, [open])
+
+  const handleChange = (e) => {
+    const { name, type, value, checked } = e.target
+    setForm(prev => ({ ...prev, [name]: type === 'checkbox' ? checked : value }))
+  }
+
+  const toggleTagId = (id) => {
+    setForm(prev => {
+      const current = prev.tag_ids || []
+      const next = current.includes(id) ? current.filter(x => x !== id) : [...current, id]
+      return { ...prev, tag_ids: next }
+    })
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    if (!form.name?.trim()) { toast.error('Nome é obrigatório'); return }
+    setSaving(true)
+    try {
+      const data = { ...form }
+      if (data.display_order !== undefined && data.display_order !== '') {
+        data.display_order = parseInt(data.display_order) || 0
+      }
+      await onSave(data)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{theme ? 'Editar Tema' : 'Novo Tema'}</DialogTitle>
+          <DialogDescription>
+            Temas aparecem no filtro público. Use linguagem de paciente (ex: "Ansiedade e estresse") e mapeie para as tags internas que ele representa.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <Label htmlFor="theme-name">Nome *</Label>
+            <Input id="theme-name" name="name" value={form.name || ''} onChange={handleChange} placeholder="Ex: Ansiedade e estresse" />
+          </div>
+          <div>
+            <Label htmlFor="theme-description">Descrição</Label>
+            <Textarea id="theme-description" name="description" value={form.description || ''} onChange={handleChange} rows={2} placeholder="Opcional — aparece como tooltip no filtro" />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label htmlFor="theme-order">Ordem de exibição</Label>
+              <Input id="theme-order" name="display_order" type="number" min="0" value={form.display_order ?? 0} onChange={handleChange} />
+            </div>
+            <div className="flex items-end pb-2">
+              <label className="inline-flex items-center gap-2 text-sm">
+                <input type="checkbox" name="active" checked={!!form.active} onChange={handleChange} />
+                Ativo (visível no filtro)
+              </label>
+            </div>
+          </div>
+          <div className="border-t pt-4">
+            <p className="text-sm font-medium mb-1">Tags internas</p>
+            <p className="text-xs text-gray-500 mb-3">Qualquer terapeuta marcado com uma dessas tags entra nesse tema.</p>
+            {availableTags.length === 0 ? (
+              <p className="text-xs text-gray-400">Nenhuma tag cadastrada.</p>
+            ) : (
+              <div className="flex flex-wrap gap-1.5 max-h-56 overflow-y-auto">
+                {availableTags.map(tag => {
+                  const selected = (form.tag_ids || []).includes(tag.id)
+                  return (
+                    <button
+                      type="button"
+                      key={tag.id}
+                      onClick={() => toggleTagId(tag.id)}
+                      className={
+                        "px-2.5 py-1 rounded-full text-xs border transition-colors " +
+                        (selected
+                          ? "bg-primary text-white border-primary"
+                          : "bg-white text-gray-700 border-gray-200 hover:border-gray-400")
+                      }
+                    >
+                      {tag.name}
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+            <p className="text-xs text-gray-500 mt-2">
+              {(form.tag_ids || []).length} tag{(form.tag_ids || []).length === 1 ? '' : 's'} selecionada{(form.tag_ids || []).length === 1 ? '' : 's'}
+            </p>
+          </div>
+          <DialogFooter>
+            <Button type="submit" disabled={saving}>
+              {saving ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
+              {theme ? 'Salvar' : 'Criar'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/src/pages/ClientDashboardPage.jsx
+++ b/src/pages/ClientDashboardPage.jsx
@@ -27,6 +27,8 @@ import activityService from '../services/activityService'
 import { blogService } from '../services/blogService'
 import horizontalLogo from '../assets/horizontal-logo.png'
 import ClientBottomNav from '../components/ClientBottomNav'
+import { openWhatsApp } from '../utils/whatsapp'
+import { track } from '../services/analytics'
 
 const MOOD_EMOJIS = ['', '😞', '😕', '😐', '🙂', '😄']
 const MOOD_COLORS = ['', '#ef4444', '#f97316', '#eab308', '#22c55e', '#10b981']
@@ -369,10 +371,13 @@ export default function ClientDashboardPage() {
                       variant="outline"
                       className="rounded-lg text-gray-500 hover:text-indigo-700 border-gray-200"
                       onClick={() => {
-                        const message = encodeURIComponent(
-                          `Olá! Gostaria de reagendar minha sessão do dia ${nextAppointment.formatted_date || nextAppointment.date} às ${nextAppointment.formatted_time || nextAppointment.time}. Meu nome é ${firstName}.`
-                        )
-                        window.open(`https://wa.me/5511914214449?text=${message}`, '_blank')
+                        track('WhatsApp Click', {
+                          source: 'dashboard_reschedule',
+                          path: window.location.pathname,
+                        })
+                        openWhatsApp({
+                          message: `Olá! Gostaria de reagendar minha sessão do dia ${nextAppointment.formatted_date || nextAppointment.date} às ${nextAppointment.formatted_time || nextAppointment.time}. Meu nome é ${firstName}.`,
+                        })
                       }}
                     >
                       <MessageCircle className="h-3.5 w-3.5 mr-1" />

--- a/src/pages/EnigmaQuizPage.jsx
+++ b/src/pages/EnigmaQuizPage.jsx
@@ -7,6 +7,8 @@ import { Label } from '@/components/ui/label.jsx'
 import { MessageCircle, ArrowRight, Lock, Eye, Heart, Sparkles } from 'lucide-react'
 import leadService from '../services/leadService'
 import horizontalLogo from '../assets/horizontal-logo.png'
+import { openWhatsApp } from '../utils/whatsapp'
+import { track } from '../services/analytics'
 
 function formatPhone(value) {
   const digits = value.replace(/\D/g, '').slice(0, 11)
@@ -24,7 +26,6 @@ function isValidEmail(value) {
 }
 
 const CORRECT_ANSWER = '33'
-const WHATSAPP_NUMBER = '5511914214449'
 
 const fonts = {
   serif: "'EB Garamond', Georgia, serif",
@@ -147,10 +148,13 @@ export default function EnigmaQuizPage() {
   }
 
   const handleWhatsAppClick = () => {
-    const message = encodeURIComponent(
-      `Oi! Descobri o enigma escondido no artigo sobre luto no trabalho. O texto me tocou e gostaria de conversar com um psicólogo.`
-    )
-    window.open(`https://wa.me/${WHATSAPP_NUMBER}?text=${message}`, '_blank')
+    track('WhatsApp Click', {
+      source: 'enigma_quiz_page',
+      path: window.location.pathname,
+    })
+    openWhatsApp({
+      message: `Oi! Descobri o enigma escondido no artigo sobre luto no trabalho. O texto me tocou e gostaria de conversar com um psicólogo.`,
+    })
   }
 
   const scrollToQuiz = () => {

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -1,11 +1,13 @@
 import { Button } from '@/components/ui/button.jsx'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card.jsx'
 import { Badge } from '@/components/ui/badge.jsx'
-import { Heart, Clock, Shield, Star, Users, ArrowRight, BookOpen } from 'lucide-react'
+import { Heart, Clock, ShieldCheck, Users, ArrowRight, BookOpen, Filter, Calendar, MessageCircle } from 'lucide-react'
 import { useNavigate, Link } from 'react-router-dom'
 import { useState, useEffect } from 'react'
 import TherapistsList from '../components/TherapistsList.jsx'
 import ExitIntentModal from '../components/ExitIntentModal.jsx'
+import WhatsAppButton from '../components/WhatsAppButton.jsx'
+import PrivacyStrip from '../components/PrivacyStrip.jsx'
 import useExitIntent from '../hooks/useExitIntent.js'
 import authService from '../services/authService.js'
 import { blogService } from '../services/blogService.js'
@@ -61,44 +63,44 @@ export default function LandingPage() {
           <div className="grid lg:grid-cols-2 gap-12 items-center">
             <div>
               <h1 className="text-5xl font-bold text-gray-900 mb-6">
-                Saúde Mental <span className="text-blue-600">Acessível</span> e Especializada
+                Encontre o psicólogo certo — com <span className="text-blue-600">privacidade</span> de verdade.
               </h1>
               <p className="text-xl text-gray-600 mb-8">
-                Acesse conteúdo de qualidade sobre bem-estar e conecte-se com psicólogos
-                especializados. Informação confiável e profissionais qualificados em um só lugar.
+                Sem anúncios baseados no seu sofrimento, sem rastreio invasivo.
+                Só cuidado profissional, no seu ritmo.
               </p>
               <div className="flex flex-col sm:flex-row gap-4">
                 <Button
                   size="lg"
                   className="bg-blue-600 hover:bg-blue-700 text-white px-8 py-4 text-lg"
-                  onClick={() => navigate('/blog')}
-                >
-                  Explorar Blog
-                  <BookOpen className="ml-2 h-5 w-5" />
-                </Button>
-                <Button
-                  variant="outline"
-                  size="lg"
-                  className="px-8 py-4 text-lg"
                   onClick={() => {
                     document.getElementById('terapeutas')?.scrollIntoView({ behavior: 'smooth' })
                   }}
                 >
-                  Conhecer Terapeutas
+                  Encontrar meu psicólogo
+                  <ArrowRight className="ml-2 h-5 w-5" />
                 </Button>
+                <WhatsAppButton
+                  source="hero"
+                  label="Falar no WhatsApp"
+                  message="Oi, cheguei pelo site e queria conversar antes de marcar uma sessão."
+                  variant="outline"
+                  size="lg"
+                  className="px-8 py-4 text-lg"
+                />
               </div>
-              <div className="mt-8 flex items-center space-x-6 text-sm text-gray-500">
+              <div className="mt-8 flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-gray-500">
                 <div className="flex items-center">
-                  <BookOpen className="h-4 w-4 mr-1" />
-                  Conteúdo Confiável
+                  <ShieldCheck className="h-4 w-4 mr-1 text-emerald-600" />
+                  100% privado
                 </div>
                 <div className="flex items-center">
-                  <Users className="h-4 w-4 mr-1" />
-                  Psicólogos Especializados
+                  <Users className="h-4 w-4 mr-1 text-blue-600" />
+                  Psicólogos registrados
                 </div>
                 <div className="flex items-center">
-                  <Shield className="h-4 w-4 mr-1" />
-                  100% Seguro
+                  <MessageCircle className="h-4 w-4 mr-1 text-emerald-600" />
+                  Atendimento humano
                 </div>
               </div>
             </div>
@@ -122,25 +124,28 @@ export default function LandingPage() {
         </div>
       </section>
 
+      {/* Privacy Strip */}
+      <PrivacyStrip />
+
       {/* How It Works */}
       <section id="como-funciona" className="py-20 bg-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
             <h2 className="text-4xl font-bold text-gray-900 mb-4">Como Funciona</h2>
-            <p className="text-xl text-gray-600">Três passos simples para cuidar da sua saúde mental</p>
+            <p className="text-xl text-gray-600">Três passos simples para encontrar cuidado psicológico</p>
           </div>
           <div className="grid md:grid-cols-3 gap-8">
             <Card className="text-center p-6">
               <CardHeader>
                 <div className="mx-auto w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mb-4">
-                  <BookOpen className="h-8 w-8 text-blue-600" />
+                  <Filter className="h-8 w-8 text-blue-600" />
                 </div>
-                <CardTitle>1. Leia Artigos</CardTitle>
+                <CardTitle>1. Filtre por demanda</CardTitle>
               </CardHeader>
               <CardContent>
                 <p className="text-gray-600">
-                  Explore nosso blog com conteúdo confiável sobre saúde mental, bem-estar e
-                  autoconhecimento escrito por profissionais qualificados.
+                  Diga o que você está buscando — tipo de atendimento, gênero do profissional,
+                  temas ou localização. A gente filtra pra você.
                 </p>
               </CardContent>
             </Card>
@@ -150,12 +155,12 @@ export default function LandingPage() {
                 <div className="mx-auto w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mb-4">
                   <Users className="h-8 w-8 text-green-600" />
                 </div>
-                <CardTitle>2. Escolha seu Psicólogo</CardTitle>
+                <CardTitle>2. Escolha seu psicólogo</CardTitle>
               </CardHeader>
               <CardContent>
                 <p className="text-gray-600">
-                  Conheça nossos psicólogos especializados, veja seus perfis,
-                  especialidades e encontre o profissional ideal para você.
+                  Conheça os profissionais que combinam com você: perfis, especialidades
+                  e abordagem. Sem overwhelm, sem paradoxo da escolha.
                 </p>
               </CardContent>
             </Card>
@@ -163,14 +168,14 @@ export default function LandingPage() {
             <Card className="text-center p-6">
               <CardHeader>
                 <div className="mx-auto w-16 h-16 bg-purple-100 rounded-full flex items-center justify-center mb-4">
-                  <Clock className="h-8 w-8 text-purple-600" />
+                  <Calendar className="h-8 w-8 text-purple-600" />
                 </div>
-                <CardTitle>3. Marque sua Sessão</CardTitle>
+                <CardTitle>3. Marque sua sessão</CardTitle>
               </CardHeader>
               <CardContent>
                 <p className="text-gray-600">
-                  Acesse a página do profissional escolhido e agende sua sessão
-                  diretamente através do sistema de agendamento deles.
+                  Agende direto na plataforma ou fale com a gente no WhatsApp.
+                  Primeiro contato humano, sempre.
                 </p>
               </CardContent>
             </Card>
@@ -337,10 +342,19 @@ export default function LandingPage() {
       <ExitIntentModal
         open={exitIntentOpen}
         onOpenChange={(open) => { if (!open) closeExitIntent() }}
-        title="Antes de ir, quer conhecer nossos psicólogos?"
-        subtitle="Às vezes, o primeiro passo é o mais difícil."
-        ctaLabel="Ver psicólogos"
-        ctaTo="/matching"
+        title="Às vezes o primeiro passo é só conversar."
+        subtitle="A Sessão de Acolhimento foi pensada para quem ainda não sabe por onde começar."
+        ctaLabel="Conhecer a Sessão de Acolhimento"
+        ctaTo="/acolhimento"
+        secondary={
+          <WhatsAppButton
+            source="exit_modal"
+            label="Falar no WhatsApp"
+            message="Oi, cheguei pelo site e queria saber mais antes de marcar."
+            variant="outline"
+            className="w-full"
+          />
+        }
       />
     </div>
   )

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -4,7 +4,7 @@ import { Badge } from '@/components/ui/badge.jsx'
 import { Heart, Clock, ShieldCheck, Users, ArrowRight, BookOpen, Filter, Calendar, MessageCircle } from 'lucide-react'
 import { useNavigate, Link } from 'react-router-dom'
 import { useState, useEffect } from 'react'
-import TherapistsList from '../components/TherapistsList.jsx'
+import TherapistFinder from '../components/therapist-finder/TherapistFinder.jsx'
 import ExitIntentModal from '../components/ExitIntentModal.jsx'
 import WhatsAppButton from '../components/WhatsAppButton.jsx'
 import PrivacyStrip from '../components/PrivacyStrip.jsx'
@@ -183,9 +183,14 @@ export default function LandingPage() {
         </div>
       </section>
 
-      {/* Therapists List Section */}
-      <section id="terapeutas" className="py-20 bg-white">
-        <TherapistsList />
+      {/* Therapists Finder Section */}
+      <section id="terapeutas" className="py-16 bg-white">
+        <TherapistFinder
+          heading="Encontre seu psicólogo"
+          subheading="Filtre por demanda. Sem paradoxo da escolha."
+          initialDisplay={3}
+          pageSize={6}
+        />
       </section>
 
       {/* Blog Preview Section */}

--- a/src/pages/MatchingPage.jsx
+++ b/src/pages/MatchingPage.jsx
@@ -1,63 +1,14 @@
-import { useState, useEffect } from 'react'
-import { useNavigate, useLocation } from 'react-router-dom'
-import { Button } from '@/components/ui/button.jsx'
+import { useLocation } from 'react-router-dom'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card.jsx'
-import { Star, CheckCircle, Calendar, Brain, Clock, ExternalLink } from 'lucide-react'
-import therapistService from '../services/therapistService'
+import { CheckCircle, Calendar } from 'lucide-react'
 import authService from '../services/authService'
 import ClientBottomNav from '../components/ClientBottomNav'
+import TherapistFinder from '../components/therapist-finder/TherapistFinder.jsx'
 
 export default function MatchingPage() {
-  const navigate = useNavigate()
   const location = useLocation()
   const { formData, priorityTherapistId } = location.state || {}
   const isLoggedIn = authService.isLoggedIn()
-
-  const [therapists, setTherapists] = useState([])
-  const [loadingTherapists, setLoadingTherapists] = useState(false)
-  const [therapistError, setTherapistError] = useState(null)
-
-  useEffect(() => {
-    fetchTherapists()
-  }, [])
-
-  const fetchTherapists = async () => {
-    setLoadingTherapists(true)
-    setTherapistError(null)
-    try {
-      const data = await therapistService.getAllTherapists()
-      const formattedTherapists = therapistService.formatTherapistsForUI(data)
-      if (priorityTherapistId) {
-        const priorityIdx = formattedTherapists.findIndex(t => t.id === priorityTherapistId)
-        if (priorityIdx > 0) {
-          const [priority] = formattedTherapists.splice(priorityIdx, 1)
-          formattedTherapists.unshift(priority)
-        }
-      }
-      setTherapists(formattedTherapists)
-    } catch (error) {
-      console.error('Failed to load therapists:', error)
-      setTherapistError('Não foi possível carregar os terapeutas. Por favor, tente novamente.')
-    } finally {
-      setLoadingTherapists(false)
-    }
-  }
-
-  const handleServiceClick = (therapist, service) => {
-    if (!isLoggedIn) {
-      navigate('/form')
-      return
-    }
-    navigate('/scheduling', { state: { therapistId: therapist.id, serviceId: service.id } })
-  }
-
-  const getLowestPrice = (therapist) => {
-    if (therapist.services && therapist.services.length > 0) {
-      const prices = therapist.services.map(s => parseFloat(s.price))
-      return Math.min(...prices)
-    }
-    return null
-  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-green-50 py-12 pb-24">
@@ -69,117 +20,37 @@ export default function MatchingPage() {
             </CardTitle>
             <CardDescription className="text-lg">
               {formData
-                ? 'Baseado no seu perfil, encontramos estes profissionais ideais'
-                : 'Conheça nossa equipe de profissionais licenciados'}
+                ? 'Baseado no seu perfil, encontramos estes profissionais.'
+                : 'Filtre por demanda para encontrar quem combina com você.'}
             </CardDescription>
           </CardHeader>
           <CardContent>
-            {therapistError && (
-              <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
-                <p className="text-red-800">{therapistError}</p>
-              </div>
-            )}
-
-            {loadingTherapists ? (
-              <div className="flex justify-center items-center py-12">
-                <div className="text-center">
-                  <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
-                  <p className="mt-4 text-gray-600">Carregando terapeutas disponíveis...</p>
-                </div>
-              </div>
-            ) : (
-              <div className="grid md:grid-cols-3 gap-6">
-                {therapists.map((therapist) => {
-                  const lowestPrice = getLowestPrice(therapist)
-
-                  return (
-                    <Card key={therapist.id} className="relative flex flex-col">
-                      <CardHeader className="text-center">
-                        {therapist.image && therapist.image !== '👨‍⚕️' ? (
-                          <img
-                            src={therapist.image}
-                            alt={therapist.name}
-                            className="w-16 h-16 rounded-full object-cover mx-auto mb-4"
-                          />
-                        ) : (
-                          <div className="w-16 h-16 rounded-full bg-purple-100 flex items-center justify-center mx-auto mb-4">
-                            <Brain className="h-9 w-9 text-purple-600" />
-                          </div>
-                        )}
-                        <CardTitle className="text-xl">{therapist.name}</CardTitle>
-                        <CardDescription>{therapist.specialty}</CardDescription>
-                        <div className="flex items-center justify-center space-x-1 mt-2">
-                          <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" />
-                          <span className="font-semibold">{therapist.rating}</span>
-                          <span className="text-gray-500">({therapist.experience})</span>
-                        </div>
-                      </CardHeader>
-                      <CardContent className="text-center flex-1 flex flex-col">
-                        <div className="space-y-2 mb-6">
-                          {lowestPrice && (
-                            <div className="text-sm">
-                              <span className="text-green-600 font-bold">a partir de R$ {lowestPrice.toFixed(0)}</span>
-                            </div>
-                          )}
-                          <div className="text-sm">
-                            <span className="text-green-600 font-semibold">{therapist.available}</span>
-                          </div>
-                        </div>
-
-                        <div className="text-xs text-gray-500 mb-4">
-                          {therapist.crpNumber && <span>CRP: {therapist.crpNumber}</span>}
-                          {therapist.crpNumber && therapist.personalSiteUrl && <span> · </span>}
-                          {therapist.personalSiteUrl && (
-                            <a
-                              href={therapist.personalSiteUrl}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="text-blue-600 hover:underline inline-flex items-center gap-0.5"
-                            >
-                              <ExternalLink className="h-3 w-3" />
-                              Site
-                            </a>
-                          )}
-                        </div>
-
-                        <div className="space-y-2 mt-auto">
-                          {therapist.services.length > 0 ? (
-                            <Button
-                              className="w-full"
-                              onClick={() => handleServiceClick(therapist, therapist.services[0])}
-                            >
-                              <Clock className="h-4 w-4 mr-2" />
-                              Agendar Sessão
-                            </Button>
-                          ) : (
-                            <p className="text-sm text-gray-500">Nenhum serviço disponível no momento</p>
-                          )}
-                        </div>
-                      </CardContent>
-                    </Card>
-                  )
-                })}
-              </div>
-            )}
+            <TherapistFinder
+              showPrompt={false}
+              priorityTherapistId={priorityTherapistId}
+              heading=""
+              subheading=""
+              pageSize={6}
+            />
 
             {isLoggedIn && (
-            <div className="mt-12 bg-green-50 p-6 rounded-lg">
-              <h3 className="text-lg font-semibold text-green-900 mb-4">Parabéns! Você está quase lá:</h3>
-              <div className="grid md:grid-cols-2 gap-4 text-sm">
-                <div className="flex items-center text-green-800">
-                  <CheckCircle className="h-4 w-4 text-green-600 mr-2" />
-                  Perfil criado e analisado
-                </div>
-                <div className="flex items-center text-green-800">
-                  <CheckCircle className="h-4 w-4 text-green-600 mr-2" />
-                  Psicólogos compatíveis encontrados
-                </div>
-                <div className="flex items-center text-green-800">
-                  <Calendar className="h-4 w-4 text-green-600 mr-2" />
-                  Próximo: Escolher psicólogo e agendar
+              <div className="mt-12 bg-green-50 p-6 rounded-lg">
+                <h3 className="text-lg font-semibold text-green-900 mb-4">Parabéns! Você está quase lá:</h3>
+                <div className="grid md:grid-cols-2 gap-4 text-sm">
+                  <div className="flex items-center text-green-800">
+                    <CheckCircle className="h-4 w-4 text-green-600 mr-2" />
+                    Perfil criado e analisado
+                  </div>
+                  <div className="flex items-center text-green-800">
+                    <CheckCircle className="h-4 w-4 text-green-600 mr-2" />
+                    Psicólogos compatíveis encontrados
+                  </div>
+                  <div className="flex items-center text-green-800">
+                    <Calendar className="h-4 w-4 text-green-600 mr-2" />
+                    Próximo: Escolher psicólogo e agendar
+                  </div>
                 </div>
               </div>
-            </div>
             )}
           </CardContent>
         </Card>

--- a/src/services/adminService.js
+++ b/src/services/adminService.js
@@ -78,6 +78,37 @@ class AdminService {
     return api.request(`/admin/therapists/${id}/toggle_active`, { method: 'PATCH' })
   }
 
+  async getTags() {
+    // Public endpoint; returns { tags: [{id, name, slug, articles_count}] }
+    const res = await api.get('/tags')
+    return res?.tags || []
+  }
+
+  // Themes (admin)
+  async getThemes() {
+    return api.get('/admin/themes')
+  }
+
+  async getTheme(id) {
+    return api.get(`/admin/themes/${id}`)
+  }
+
+  async createTheme(data) {
+    return api.post('/admin/themes', { theme: data })
+  }
+
+  async updateTheme(id, data) {
+    return api.put(`/admin/themes/${id}`, { theme: data })
+  }
+
+  async toggleThemeActive(id) {
+    return api.request(`/admin/themes/${id}/toggle_active`, { method: 'PATCH' })
+  }
+
+  async deleteTheme(id) {
+    return api.delete(`/admin/themes/${id}`)
+  }
+
   // Clients
   async getClients(q = '') {
     const params = q ? { q } : {}

--- a/src/services/therapistService.js
+++ b/src/services/therapistService.js
@@ -54,6 +54,30 @@ class TherapistService {
     return this.getAllTherapists({ specialty });
   }
 
+  async getFilteredTherapists(filters = {}) {
+    const params = {};
+    if (filters.gender) params.gender = filters.gender;
+    if (filters.audience) params.audience = filters.audience;
+    if (filters.modality) params.modality = filters.modality;
+    if (filters.theme_ids && filters.theme_ids.length) params.theme_ids = filters.theme_ids.join(',');
+    if (filters.tag_ids && filters.tag_ids.length) params.tag_ids = filters.tag_ids.join(',');
+    if (filters.cep) params.cep = filters.cep.replace(/\D/g, '');
+    if (filters.radius_km) params.radius_km = filters.radius_km;
+    if (filters.specialty) params.specialty = filters.specialty;
+    if (filters.highly_rated) params.highly_rated = 'true';
+    return this.getAllTherapists(params);
+  }
+
+  async getPublicTags() {
+    const res = await api.get('/tags');
+    return res?.tags || [];
+  }
+
+  async getPublicThemes() {
+    const res = await api.get('/themes');
+    return res?.themes || [];
+  }
+
   formatTherapistForUI(therapist) {
     return {
       id: therapist.id,
@@ -70,7 +94,14 @@ class TherapistService {
       crpNumber: therapist.crp_number,
       personalSiteUrl: therapist.personal_site_url,
       calendlyUrl: therapist.calendly_url,
-      services: therapist.services || []
+      services: therapist.services || [],
+      gender: therapist.gender,
+      pronouns: therapist.pronouns,
+      audiences: therapist.audiences || { children: false, teens: false, adults: true },
+      modalities: therapist.modalities || { remote: true, presencial: false },
+      offices: therapist.offices || [],
+      nearestOffice: therapist.nearest_office || null,
+      tags: therapist.tags || []
     };
   }
 

--- a/src/utils/whatsapp.js
+++ b/src/utils/whatsapp.js
@@ -1,0 +1,12 @@
+export const WHATSAPP_NUMBER = '5511914214449'
+
+export function buildWhatsAppUrl({ message } = {}) {
+  const base = `https://wa.me/${WHATSAPP_NUMBER}`
+  if (!message) return base
+  const encoded = typeof message === 'string' ? encodeURIComponent(message) : message
+  return `${base}?text=${encoded}`
+}
+
+export function openWhatsApp({ message } = {}) {
+  window.open(buildWhatsAppUrl({ message }), '_blank')
+}


### PR DESCRIPTION
## Summary

Two layers of change for the home-page refactor:

- **Phase A — privacy-forward hero + WhatsApp centralization.** New hero copy leans on real product privacy (no sofrimento-based ads, no Google Analytics, no data resale). Como Funciona rewritten to match the filter-first flow. Exit-intent modal refocused from "ver psicólogos → /matching" to "o primeiro passo é só conversar → /acolhimento" with a secondary WhatsApp CTA. New \`WhatsAppButton\` component + \`utils/whatsapp.js\` centralize the phone number and replace 5 hardcoded \`wa.me\` URLs across the app.
- **Phases B + C + D — filter-first therapist discovery UX.** Replaces \`<TherapistsList />\` with a prompt → filter → results flow: gender / audience / modality / CEP+radius / theme chips. Therapist cards show multi-office info with nearest-office distance when the CEP filter is active. Pagination on LandingPage (3 initial → "Ver todos" → 6/page) keeps paradox-of-choice in check; MatchingPage starts paginated. Admin therapist form gets new filter fields and a dynamic repeatable offices section. New Temas admin tab for curating theme-to-tag mappings database-driven.

### Code-review pass

Ran \`feature-dev:code-reviewer\` before committing. All flagged issues fixed:
- Fetch race condition — added sequence-counter guard in \`TherapistFinder\` so stale responses from superseded filter changes are discarded.
- Stale \`filterKey\` closure on \`Filter Applied\` event — captured key at call time.
- \`setSaving(false)\` wrapped in \`try/finally\` for \`TherapistFormDialog\` and \`ThemeFormDialog\`.
- \`WhatsAppButton\` analytics guard — skips \`track()\` on right-click, middle-click, and modifier clicks (those open link in new tab, don't actually open WhatsApp).

### Commits

1. \`feat: privacy-forward landing hero + centralized WhatsApp CTAs\` — Phase A (frontend-only, visible marketing wins with no backend dependency)
2. \`feat: filter-first therapist discovery UX with offices and themes\` — Phases B+C+D (filter UX, offices, themes — evolved together on the same components)

## Depends on

Backend PR: https://github.com/monoxchd/psicologia-platform-api/pull/48

The filter + office + theme endpoints land in that repo. Merge backend first (or both together) to avoid a broken home page between deploys.

## Test plan

### Phase A (frontend-only)
- [ ] \`npm run dev\` → home page shows new hero copy + privacy strip between hero and Como Funciona
- [ ] Como Funciona shows: Filtre por demanda → Escolha seu psicólogo → Marque sua sessão
- [ ] Exit intent: move cursor to top of browser on desktop → modal shows "o primeiro passo é só conversar" with primary CTA → /acolhimento and secondary WhatsApp button
- [ ] Mobile: scroll past ~85% of page → modal fires (clear \`tc_exit_intent_landing\` in localStorage between runs)
- [ ] Acolhimento hero WhatsApp, Acolhimento fixed-footer WhatsApp, Dashboard reschedule WhatsApp, both Enigma quiz WhatsApp CTAs still open \`wa.me/5511914214449\` with the correct pre-filled message
- [ ] Plausible events: \`WhatsApp Click\` fires with correct \`source\` (hero / exit_modal / acolhimento / dashboard_reschedule / enigma_quiz_page / enigma_quiz_inline / empty_results)
- [ ] Right-click on WhatsApp button → no \`WhatsApp Click\` event (guard works)

### Phase B+C+D (filter-first UX)
- [ ] LandingPage shows prompt tiles first; clicking a tile routes to results with 3 cards visible
- [ ] "Ver todos os N psicólogos" button reveals paginated view (6/page) with prev/next
- [ ] FilterBar: gender chips, audience chips, modality toggle, theme chips all filter the result set with debounced re-fetch
- [ ] Presencial modality reveals CEP input + radius chips; entering a valid CEP returns distance-sorted results with "mais próximo: X · Y km" on each card
- [ ] Rapid filter changes don't produce flicker from stale responses (sequence guard)
- [ ] MatchingPage shows paginated results without the prompt tiles and honors \`priorityTherapistId\` from blog exit-intent
- [ ] Empty state: apply an impossible filter combo → "Fale no WhatsApp" CTA appears, fires with \`source="empty_results"\`
- [ ] Admin /admin → Terapeutas → edit therapist: add gender, audiences, modality, multiple offices (add/remove/active toggle), tag chips. Save succeeds; offices get geocoded asynchronously
- [ ] Admin /admin → Temas tab: create new theme, assign tags, toggle active, delete; public filter reflects changes within one page refresh
- [ ] \`npm run build\` completes clean (currently 7.97s, ~1.97 MB bundle with the same pre-existing chunk-size warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)