### PR TITLE
fix: CEP input mask on filter bar and admin offices form

### DIFF
--- a/src/components/therapist-finder/FilterBar.jsx
+++ b/src/components/therapist-finder/FilterBar.jsx
@@ -3,6 +3,7 @@ import { Input } from '@/components/ui/input.jsx'
 import { Button } from '@/components/ui/button.jsx'
 import { X, Video, MapPin, Filter as FilterIcon } from 'lucide-react'
 import therapistService from '../../services/therapistService'
+import { formatCep } from '../../utils/cep'
 
 const GENDER_OPTIONS = [
   { value: 'female', label: 'Feminino' },
@@ -121,11 +122,12 @@ export default function FilterBar({ filters, onChange, onClear, totalCount }) {
           <FilterRow label="Proximidade">
             <div className="flex flex-wrap items-center gap-2">
               <Input
-                value={filters.cep || ''}
-                onChange={e => setField('cep', e.target.value)}
-                placeholder="Seu CEP"
+                value={formatCep(filters.cep || '')}
+                onChange={e => setField('cep', formatCep(e.target.value))}
+                placeholder="00000-000"
                 className="w-32"
                 maxLength={9}
+                inputMode="numeric"
               />
               <div className="flex gap-1">
                 {RADIUS_OPTIONS.map(km => (

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -29,6 +29,7 @@ import {
 
 import authService from '@/services/authService.js'
 import adminService from '@/services/adminService.js'
+import { formatCep } from '@/utils/cep'
 
 const ADMIN_EMAIL = 'dneves.junior@gmail.com'
 
@@ -1288,10 +1289,11 @@ function TherapistFormDialog({ open, onOpenChange, therapist, onSave }) {
                           <div>
                             <Label className="text-xs">CEP</Label>
                             <Input
-                              value={office.cep || ''}
-                              onChange={e => updateOffice(idx, 'cep', e.target.value)}
-                              placeholder="04038000"
+                              value={formatCep(office.cep || '')}
+                              onChange={e => updateOffice(idx, 'cep', formatCep(e.target.value))}
+                              placeholder="00000-000"
                               maxLength={9}
+                              inputMode="numeric"
                               className="bg-white"
                             />
                           </div>

--- a/src/utils/cep.js
+++ b/src/utils/cep.js
@@ -1,0 +1,13 @@
+export function formatCep(value) {
+  const digits = String(value || '').replace(/\D/g, '').slice(0, 8)
+  if (digits.length <= 5) return digits
+  return `${digits.slice(0, 5)}-${digits.slice(5)}`
+}
+
+export function stripCep(value) {
+  return String(value || '').replace(/\D/g, '')
+}
+
+export function isValidCep(value) {
+  return /^\d{8}$/.test(stripCep(value))
+}


### PR DESCRIPTION
## Summary

Users were typing CEPs in inconsistent shapes (\`05624-070\`, \`05624070\`, copy-paste with whitespace). Adds a shared mask that formats as \`XXXXX-XXX\` while typing.

- New \`src/utils/cep.js\` with \`formatCep\`, \`stripCep\`, \`isValidCep\` — reused wherever a CEP input appears.
- \`FilterBar.jsx\` — value + onChange wrapped with \`formatCep\`, placeholder is \`00000-000\`, \`inputMode="numeric"\` for mobile keyboards.
- \`AdminPage.jsx\` therapist-office rows — same treatment in the offices list.

Backend already strips non-digits before calling the geocoder, so this is purely a UX fix — no API contract change.

## Related

Depends on — or pairs with — backend PR monoxchd/psicologia-platform-api#49 which makes the CEP geocoder robust to Nominatim misses. Either can merge first; the backend fix unblocks valid CEPs that were silently failing, the frontend fix prevents users from sending malformed ones.

## Test plan

- [ ] Type \`05624070\` in the filter CEP → input displays \`05624-070\`
- [ ] Type \`05624-070\` → input stays as-is
- [ ] Paste \`05624 070\` or \`abc05624070xyz\` → input shows \`05624-070\`
- [ ] Enter 9+ digits → capped at 8 digits (\`XXXXX-XXX\`)
- [ ] Same behavior in admin /admin → Terapeutas → edit therapist → Locais → CEP input
- [ ] Backend receives the masked value; geocoder still works (strips dash server-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)