### PR TITLE
feat: triage flow for "Não sei por onde começar"

### DIFF
--- a/src/components/therapist-finder/FilterBar.jsx
+++ b/src/components/therapist-finder/FilterBar.jsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { Input } from '@/components/ui/input.jsx'
 import { Button } from '@/components/ui/button.jsx'
-import { X, Video, MapPin, Filter as FilterIcon } from 'lucide-react'
+import { X, Video, MapPin, Filter as FilterIcon, Compass } from 'lucide-react'
 import therapistService from '../../services/therapistService'
 import { formatCep } from '../../utils/cep'
 
@@ -158,6 +159,16 @@ export default function FilterBar({ filters, onChange, onClear, totalCount }) {
             ))}
           </FilterRow>
         )}
+      </div>
+
+      <div className="mt-4 pt-3 border-t border-gray-100 text-center">
+        <Link
+          to="/triagem"
+          className="inline-flex items-center gap-1.5 text-xs text-gray-500 hover:text-emerald-700 underline underline-offset-4"
+        >
+          <Compass className="h-3.5 w-3.5" />
+          Nenhum desses te descreve? Responda 3 perguntas →
+        </Link>
       </div>
     </div>
   )

--- a/src/components/therapist-finder/PromptTiles.jsx
+++ b/src/components/therapist-finder/PromptTiles.jsx
@@ -1,4 +1,6 @@
-import { User, Baby, Video, MapPin, Users } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+import { User, Baby, Video, MapPin, Users, Compass } from 'lucide-react'
+import { track } from '../../services/analytics'
 
 const TILES = [
   {
@@ -29,9 +31,28 @@ const TILES = [
     icon: MapPin,
     filters: { modality: 'presencial', audience: 'adults' },
   },
+  {
+    key: 'triage',
+    label: 'Não sei por onde começar',
+    caption: 'A gente te ajuda em 3 perguntas',
+    icon: Compass,
+    navigateTo: '/triagem',
+    highlight: true,
+  },
 ]
 
 export default function PromptTiles({ onSelect, onSeeAll }) {
+  const navigate = useNavigate()
+
+  const handleTileClick = (tile) => {
+    if (tile.navigateTo) {
+      track('Prompt Tile Click', { tile: tile.key, path: window.location.pathname })
+      navigate(tile.navigateTo)
+    } else {
+      onSelect(tile.filters, tile.key)
+    }
+  }
+
   return (
     <div className="max-w-4xl mx-auto">
       <div className="text-center mb-8">
@@ -45,15 +66,26 @@ export default function PromptTiles({ onSelect, onSeeAll }) {
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         {TILES.map(tile => {
           const Icon = tile.icon
+          const highlighted = tile.highlight
           return (
             <button
               key={tile.key}
               type="button"
-              onClick={() => onSelect(tile.filters, tile.key)}
-              className="group flex items-center gap-4 p-5 rounded-xl border border-gray-200 bg-white hover:border-blue-500 hover:shadow-md transition-all text-left"
+              onClick={() => handleTileClick(tile)}
+              className={
+                'group flex items-center gap-4 p-5 rounded-xl border transition-all text-left ' +
+                (highlighted
+                  ? 'border-emerald-200 bg-emerald-50/50 hover:border-emerald-500 hover:shadow-md sm:col-span-2'
+                  : 'border-gray-200 bg-white hover:border-blue-500 hover:shadow-md')
+              }
             >
-              <div className="w-12 h-12 rounded-full bg-blue-50 group-hover:bg-blue-100 flex items-center justify-center flex-shrink-0 transition-colors">
-                <Icon className="h-6 w-6 text-blue-600" />
+              <div className={
+                'w-12 h-12 rounded-full flex items-center justify-center flex-shrink-0 transition-colors ' +
+                (highlighted
+                  ? 'bg-white group-hover:bg-emerald-100'
+                  : 'bg-blue-50 group-hover:bg-blue-100')
+              }>
+                <Icon className={'h-6 w-6 ' + (highlighted ? 'text-emerald-700' : 'text-blue-600')} />
               </div>
               <div className="min-w-0">
                 <p className="font-semibold text-gray-900">{tile.label}</p>

--- a/src/components/triage/TriageFeedback.jsx
+++ b/src/components/triage/TriageFeedback.jsx
@@ -1,0 +1,63 @@
+import { useState } from 'react'
+import { track } from '../../services/analytics'
+import { submitTriageFeedback } from '../../services/triageFeedbackService.js'
+
+const OPTIONS = [
+  { id: 'sim',            emoji: '👍', label: 'Sim' },
+  { id: 'mais_ou_menos',  emoji: '🤔', label: 'Mais ou menos' },
+  { id: 'nao',            emoji: '👎', label: 'Não' },
+]
+
+export default function TriageFeedback({ tema }) {
+  const [submitted, setSubmitted] = useState(null)
+  const [error, setError] = useState(false)
+
+  const handleClick = async (resposta) => {
+    if (submitted) return
+    setSubmitted(resposta)
+    track('Triage Feedback', { tema, resposta })
+    try {
+      await submitTriageFeedback({ tema, resposta })
+    } catch (err) {
+      // Privacy contract: don't retry automatically, don't persist. The
+      // aggregated counter just misses one tick.
+      setError(true)
+    }
+  }
+
+  return (
+    <div className="mt-10 pt-6 border-t border-gray-100 text-center">
+      <p className="text-sm text-gray-600 mb-3">Essa indicação fez sentido pra você?</p>
+      <div className="flex items-center justify-center gap-2">
+        {OPTIONS.map(opt => {
+          const isSelected = submitted === opt.id
+          return (
+            <button
+              key={opt.id}
+              type="button"
+              disabled={!!submitted}
+              onClick={() => handleClick(opt.id)}
+              className={
+                'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm border transition-colors ' +
+                (isSelected
+                  ? 'bg-emerald-50 border-emerald-300 text-emerald-800'
+                  : submitted
+                    ? 'bg-white border-gray-200 text-gray-400 cursor-not-allowed'
+                    : 'bg-white border-gray-200 text-gray-700 hover:border-gray-400')
+              }
+            >
+              <span>{opt.emoji}</span>
+              {opt.label}
+            </button>
+          )
+        })}
+      </div>
+      {submitted && !error && (
+        <p className="text-xs text-gray-500 mt-3">Obrigado pela resposta.</p>
+      )}
+      {error && (
+        <p className="text-xs text-amber-700 mt-3">Não conseguimos registrar sua resposta — tudo bem, nada foi salvo.</p>
+      )}
+    </div>
+  )
+}

--- a/src/components/triage/TriageFlow.jsx
+++ b/src/components/triage/TriageFlow.jsx
@@ -1,0 +1,131 @@
+import { useReducer, useMemo } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { QUESTIONS, resolverTema } from '../../utils/triage-matrix'
+import { track } from '../../services/analytics'
+import TriageIntro from './TriageIntro.jsx'
+import TriageQuestion from './TriageQuestion.jsx'
+import TriageResultMatch from './TriageResultMatch.jsx'
+import TriageResultRedirect from './TriageResultRedirect.jsx'
+
+const initialState = {
+  screen: 'intro', // intro | p1 | p2 | p3 | result_match | result_redirect
+  answers: { p1: null, p2: null, p3: null },
+  result: null,
+}
+
+const ORDER = ['p1', 'p2', 'p3']
+
+function reducer(state, action) {
+  switch (action.type) {
+    case 'start':
+      return { ...state, screen: 'p1' }
+
+    case 'answer': {
+      const { question, value } = action
+      const nextAnswers = { ...state.answers, [question]: value }
+
+      // P1/P2 always advance. P3 finishes the flow.
+      if (question === 'p3') {
+        const result = resolverTema(nextAnswers.p1, nextAnswers.p2, value)
+        return {
+          ...state,
+          answers: nextAnswers,
+          result,
+          screen: result.tipo === 'redirecionar' ? 'result_redirect' : 'result_match',
+        }
+      }
+
+      // Special case: todo_lugar on P2 → straight to redirect.
+      if (question === 'p2' && value === 'todo_lugar') {
+        return {
+          ...state,
+          answers: nextAnswers,
+          result: { tipo: 'redirecionar' },
+          screen: 'result_redirect',
+        }
+      }
+
+      const idx = ORDER.indexOf(question)
+      const nextScreen = ORDER[idx + 1]
+      return { ...state, answers: nextAnswers, screen: nextScreen }
+    }
+
+    case 'skip': {
+      const { question } = action
+      // Skipping P1 or P2 means we can't match — redirect.
+      if (question === 'p1' || question === 'p2') {
+        return { ...state, screen: 'result_redirect', result: { tipo: 'redirecionar' } }
+      }
+      // Skipping P3: compute result without modifier.
+      if (question === 'p3') {
+        const result = resolverTema(state.answers.p1, state.answers.p2, null)
+        return {
+          ...state,
+          result,
+          screen: result.tipo === 'redirecionar' ? 'result_redirect' : 'result_match',
+        }
+      }
+      return state
+    }
+
+    case 'back': {
+      if (state.screen === 'p2') return { ...state, screen: 'p1', answers: { ...state.answers, p2: null } }
+      if (state.screen === 'p3') return { ...state, screen: 'p2', answers: { ...state.answers, p3: null } }
+      return state
+    }
+
+    default:
+      return state
+  }
+}
+
+export default function TriageFlow() {
+  const navigate = useNavigate()
+  const [state, dispatch] = useReducer(reducer, initialState)
+
+  const canGoBack = useMemo(() => state.screen === 'p2' || state.screen === 'p3', [state.screen])
+
+  const handleStart = () => {
+    track('Triage Start', {})
+    dispatch({ type: 'start' })
+  }
+
+  const handleExitFlow = () => {
+    // "Prefiro ver todos os psicólogos" on the intro.
+    navigate('/#terapeutas')
+  }
+
+  const handleAnswer = (question, value) => {
+    track('Triage Answer', { question, answer: value })
+    dispatch({ type: 'answer', question, value })
+  }
+
+  const handleSkip = (question) => {
+    track('Triage Skip', { question })
+    dispatch({ type: 'skip', question })
+  }
+
+  if (state.screen === 'intro') {
+    return <TriageIntro onStart={handleStart} onSkip={handleExitFlow} />
+  }
+
+  if (state.screen === 'result_redirect') {
+    return <TriageResultRedirect />
+  }
+
+  if (state.screen === 'result_match') {
+    return <TriageResultMatch result={state.result} />
+  }
+
+  // Question screens
+  const question = QUESTIONS[state.screen]
+  return (
+    <TriageQuestion
+      question={question}
+      canGoBack={canGoBack}
+      onAnswer={(value) => handleAnswer(state.screen, value)}
+      onBack={() => dispatch({ type: 'back' })}
+      onSkip={() => handleSkip(state.screen)}
+    />
+  )
+}

--- a/src/components/triage/TriageIntro.jsx
+++ b/src/components/triage/TriageIntro.jsx
@@ -1,0 +1,34 @@
+import { Button } from '@/components/ui/button.jsx'
+import { Lock, ArrowRight, Users } from 'lucide-react'
+
+export default function TriageIntro({ onStart, onSkip }) {
+  return (
+    <div className="max-w-2xl mx-auto text-center">
+      <h1 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-3">
+        Vamos te ajudar a encontrar o caminho
+      </h1>
+      <p className="text-lg text-gray-600 mb-8">
+        Três perguntas rápidas. Sem certo ou errado.
+      </p>
+
+      <div className="inline-flex items-start gap-3 text-left bg-emerald-50 border border-emerald-100 rounded-xl p-4 mb-8">
+        <Lock className="h-5 w-5 text-emerald-700 flex-shrink-0 mt-0.5" />
+        <p className="text-sm text-emerald-900 leading-relaxed">
+          <span className="font-semibold">Suas respostas não são salvas.</span> Esse processo acontece
+          no seu navegador e some quando você fecha a página. Nada é enviado ao servidor.
+        </p>
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-3 justify-center">
+        <Button size="lg" onClick={onStart} className="bg-blue-600 hover:bg-blue-700 text-white px-8">
+          Começar
+          <ArrowRight className="h-5 w-5 ml-2" />
+        </Button>
+        <Button size="lg" variant="outline" onClick={onSkip} className="px-8">
+          <Users className="h-4 w-4 mr-2" />
+          Prefiro ver todos os psicólogos
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/triage/TriageIntro.jsx
+++ b/src/components/triage/TriageIntro.jsx
@@ -14,8 +14,9 @@ export default function TriageIntro({ onStart, onSkip }) {
       <div className="inline-flex items-start gap-3 text-left bg-emerald-50 border border-emerald-100 rounded-xl p-4 mb-8">
         <Lock className="h-5 w-5 text-emerald-700 flex-shrink-0 mt-0.5" />
         <p className="text-sm text-emerald-900 leading-relaxed">
-          <span className="font-semibold">Suas respostas não são salvas.</span> Esse processo acontece
-          no seu navegador e some quando você fecha a página. Nada é enviado ao servidor.
+          <span className="font-semibold">Suas respostas individuais não saem do seu navegador</span> —
+          somem quando você fecha a página. Se você escolher nos dar feedback no final, enviamos apenas
+          a indicação geral (sem identificação) pra melhorar a ferramenta.
         </p>
       </div>
 

--- a/src/components/triage/TriageProgress.jsx
+++ b/src/components/triage/TriageProgress.jsx
@@ -1,0 +1,20 @@
+export default function TriageProgress({ current, total }) {
+  const percent = Math.min(100, Math.round((current / total) * 100))
+  return (
+    <div className="mb-6">
+      <div
+        className="flex items-center justify-between text-xs text-gray-500 mb-1.5"
+        aria-live="polite"
+      >
+        <span>Pergunta {current} de {total}</span>
+        <span>{percent}%</span>
+      </div>
+      <div className="h-1.5 w-full rounded-full bg-gray-100 overflow-hidden" role="progressbar" aria-valuenow={percent} aria-valuemin={0} aria-valuemax={100}>
+        <div
+          className="h-full bg-blue-600 transition-all duration-300 ease-out"
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/triage/TriageQuestion.jsx
+++ b/src/components/triage/TriageQuestion.jsx
@@ -25,15 +25,16 @@ export default function TriageQuestion({ question, onAnswer, onBack, onSkip, can
           <ChevronLeft className="h-4 w-4 mr-1" />
           Voltar
         </Button>
-        {question.skippable && (
-          <button
-            type="button"
-            onClick={onSkip}
-            className="text-sm text-gray-500 hover:text-gray-700 underline underline-offset-4"
-          >
-            Pular essa pergunta
-          </button>
-        )}
+        {/* Spec: "opção pular em toda tela". On P1/P2 the skip routes to WhatsApp
+            (handled upstream in TriageFlow's reducer); on P3 it proceeds to
+            matching without the abordagem modifier. Label stays consistent. */}
+        <button
+          type="button"
+          onClick={onSkip}
+          className="text-sm text-gray-500 hover:text-gray-700 underline underline-offset-4"
+        >
+          Pular essa pergunta
+        </button>
       </div>
 
       <h2
@@ -57,15 +58,6 @@ export default function TriageQuestion({ question, onAnswer, onBack, onSkip, can
         ))}
       </div>
 
-      {!question.skippable && (
-        <p className="text-xs text-gray-400 text-center mt-6">
-          Prefere não responder? <button
-            type="button"
-            onClick={onSkip}
-            className="underline underline-offset-2 hover:text-gray-600"
-          >Falar no WhatsApp direto</button>
-        </p>
-      )}
     </div>
   )
 }

--- a/src/components/triage/TriageQuestion.jsx
+++ b/src/components/triage/TriageQuestion.jsx
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from 'react'
+import { Button } from '@/components/ui/button.jsx'
+import { ChevronLeft } from 'lucide-react'
+import TriageProgress from './TriageProgress.jsx'
+
+export default function TriageQuestion({ question, onAnswer, onBack, onSkip, canGoBack }) {
+  const headingRef = useRef(null)
+
+  useEffect(() => {
+    headingRef.current?.focus()
+  }, [question.key])
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <TriageProgress current={question.number} total={3} />
+
+      <div className="flex items-center justify-between mb-5">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onBack}
+          disabled={!canGoBack}
+          className="text-gray-500 hover:text-gray-900 disabled:opacity-30"
+        >
+          <ChevronLeft className="h-4 w-4 mr-1" />
+          Voltar
+        </Button>
+        {question.skippable && (
+          <button
+            type="button"
+            onClick={onSkip}
+            className="text-sm text-gray-500 hover:text-gray-700 underline underline-offset-4"
+          >
+            Pular essa pergunta
+          </button>
+        )}
+      </div>
+
+      <h2
+        ref={headingRef}
+        tabIndex={-1}
+        className="text-2xl sm:text-3xl font-semibold text-gray-900 mb-6 outline-none"
+      >
+        {question.text}
+      </h2>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {question.options.map(opt => (
+          <button
+            key={opt.id}
+            type="button"
+            onClick={() => onAnswer(opt.id)}
+            className="text-left p-4 rounded-xl border border-gray-200 bg-white hover:border-blue-500 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all"
+          >
+            <span className="text-base text-gray-900">{opt.label}</span>
+          </button>
+        ))}
+      </div>
+
+      {!question.skippable && (
+        <p className="text-xs text-gray-400 text-center mt-6">
+          Prefere não responder? <button
+            type="button"
+            onClick={onSkip}
+            className="underline underline-offset-2 hover:text-gray-600"
+          >Falar no WhatsApp direto</button>
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/triage/TriageResultMatch.jsx
+++ b/src/components/triage/TriageResultMatch.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
-import { Loader2 } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+import { Loader2, ArrowRight } from 'lucide-react'
 import therapistService from '../../services/therapistService'
 import TherapistCard from '../therapist-finder/TherapistCard.jsx'
 import TriageFeedback from './TriageFeedback.jsx'
@@ -10,7 +11,10 @@ import { track } from '../../services/analytics'
 const MAX_RESULTS = 3
 
 export default function TriageResultMatch({ result }) {
+  const navigate = useNavigate()
   const [therapists, setTherapists] = useState([])
+  const [totalMatches, setTotalMatches] = useState(0)
+  const [principalThemeId, setPrincipalThemeId] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
 
@@ -28,13 +32,18 @@ export default function TriageResultMatch({ result }) {
         const principalSlug = THEME_SLUG_MAP[result.temaPrincipal]
         const secondarySlug = result.temaSecundario ? THEME_SLUG_MAP[result.temaSecundario] : null
 
+        const principalId = slugToId[principalSlug] || null
         const themeIds = [
-          slugToId[principalSlug],
+          principalId,
           secondarySlug ? slugToId[secondarySlug] : null,
         ].filter(Boolean)
 
         if (themeIds.length === 0) {
-          if (!cancelled) setTherapists([])
+          if (!cancelled) {
+            setTherapists([])
+            setTotalMatches(0)
+            setPrincipalThemeId(null)
+          }
           return
         }
 
@@ -48,10 +57,13 @@ export default function TriageResultMatch({ result }) {
 
         if (!cancelled) {
           setTherapists(ranked)
+          setTotalMatches(formatted.length)
+          setPrincipalThemeId(principalId)
           track('Triage Result Shown', {
             tema_principal: result.temaPrincipal,
             tema_secundario: result.temaSecundario || null,
             result_count: ranked.length,
+            total_matches: formatted.length,
           })
         }
       } catch (e) {
@@ -64,6 +76,15 @@ export default function TriageResultMatch({ result }) {
     load()
     return () => { cancelled = true }
   }, [result])
+
+  const handleSeeMore = () => {
+    track('Triage See More Click', {
+      tema_principal: result.temaPrincipal,
+      total_matches: totalMatches,
+    })
+    const initialFilters = principalThemeId ? { theme_ids: [principalThemeId] } : {}
+    navigate('/matching', { state: { initialFilters } })
+  }
 
   const temaNome = THEME_DISPLAY_NAME[result.temaPrincipal] || result.temaPrincipal
 
@@ -111,6 +132,20 @@ export default function TriageResultMatch({ result }) {
               <TherapistCard key={t.id} therapist={t} index={idx} />
             ))}
           </div>
+
+          {totalMatches > therapists.length && (
+            <div className="text-center mt-6">
+              <button
+                type="button"
+                onClick={handleSeeMore}
+                className="inline-flex items-center gap-1.5 text-sm text-blue-600 hover:text-blue-800 underline underline-offset-4"
+              >
+                Ver mais psicólogos que trabalham com {temaNome.toLowerCase()}
+                <ArrowRight className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          )}
+
           <TriageFeedback tema={result.temaPrincipal} />
         </>
       )}

--- a/src/components/triage/TriageResultMatch.jsx
+++ b/src/components/triage/TriageResultMatch.jsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import therapistService from '../../services/therapistService'
+import TherapistCard from '../therapist-finder/TherapistCard.jsx'
+import TriageFeedback from './TriageFeedback.jsx'
+import WhatsAppButton from '../WhatsAppButton.jsx'
+import { THEME_DISPLAY_NAME, THEME_SLUG_MAP, shuffleForEquity } from '../../utils/triage-matrix'
+import { track } from '../../services/analytics'
+
+const MAX_RESULTS = 3
+
+export default function TriageResultMatch({ result }) {
+  const [therapists, setTherapists] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      setLoading(true)
+      setError(null)
+      try {
+        const themes = await therapistService.getPublicThemes()
+        const slugToId = {}
+        themes.forEach(t => { slugToId[t.slug] = t.id })
+
+        const principalSlug = THEME_SLUG_MAP[result.temaPrincipal]
+        const secondarySlug = result.temaSecundario ? THEME_SLUG_MAP[result.temaSecundario] : null
+
+        const themeIds = [
+          slugToId[principalSlug],
+          secondarySlug ? slugToId[secondarySlug] : null,
+        ].filter(Boolean)
+
+        if (themeIds.length === 0) {
+          if (!cancelled) setTherapists([])
+          return
+        }
+
+        const data = await therapistService.getFilteredTherapists({ theme_ids: themeIds })
+        const formatted = therapistService.formatTherapistsForUI(data)
+
+        // Backend returns the union of therapists matching principal OR
+        // secondary theme. Shuffle with jitter for equity and slice. Full
+        // per-theme scoring lands with the P3 ranking follow-up.
+        const ranked = shuffleForEquity(formatted).slice(0, MAX_RESULTS)
+
+        if (!cancelled) {
+          setTherapists(ranked)
+          track('Triage Result Shown', {
+            tema_principal: result.temaPrincipal,
+            tema_secundario: result.temaSecundario || null,
+            result_count: ranked.length,
+          })
+        }
+      } catch (e) {
+        if (!cancelled) setError('Não conseguimos carregar os psicólogos agora. Tente novamente em instantes.')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    load()
+    return () => { cancelled = true }
+  }, [result])
+
+  const temaNome = THEME_DISPLAY_NAME[result.temaPrincipal] || result.temaPrincipal
+
+  return (
+    <div className="max-w-5xl mx-auto">
+      <div className="text-center mb-8">
+        <h2 className="text-2xl sm:text-3xl font-semibold text-gray-900 mb-2">
+          Acho que esses profissionais podem te ajudar
+        </h2>
+        <p className="text-gray-600">
+          Com base no que você compartilhou, reuni profissionais que trabalham com{' '}
+          <span className="font-semibold text-gray-900">{temaNome}</span>.
+        </p>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6 text-center">
+          <p className="text-red-800 text-sm">{error}</p>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex justify-center py-14">
+          <Loader2 className="h-8 w-8 animate-spin text-blue-600" />
+        </div>
+      ) : therapists.length === 0 ? (
+        <div className="text-center py-10 px-4 rounded-2xl border border-dashed border-gray-200 bg-gray-50">
+          <p className="text-base font-semibold text-gray-900 mb-2">
+            Ainda não temos psicólogos cadastrados nesse tema
+          </p>
+          <p className="text-sm text-gray-500 mb-5">
+            Fale com a gente no WhatsApp — ajudamos você a encontrar quem combina.
+          </p>
+          <WhatsAppButton
+            source="triagem_empty"
+            label="Falar no WhatsApp"
+            message={`Oi! Fiz a triagem no site e cheguei no tema "${temaNome}", mas não vi psicólogos. Pode me ajudar?`}
+            variant="outline"
+          />
+        </div>
+      ) : (
+        <>
+          <div className="grid gap-5 md:grid-cols-3">
+            {therapists.map((t, idx) => (
+              <TherapistCard key={t.id} therapist={t} index={idx} />
+            ))}
+          </div>
+          <TriageFeedback tema={result.temaPrincipal} />
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/triage/TriageResultRedirect.jsx
+++ b/src/components/triage/TriageResultRedirect.jsx
@@ -1,0 +1,43 @@
+import { useNavigate } from 'react-router-dom'
+import { Button } from '@/components/ui/button.jsx'
+import { MessageCircleHeart, Users } from 'lucide-react'
+import WhatsAppButton from '../WhatsAppButton.jsx'
+
+export default function TriageResultRedirect() {
+  const navigate = useNavigate()
+
+  return (
+    <div className="max-w-2xl mx-auto text-center">
+      <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-emerald-50 mb-5">
+        <MessageCircleHeart className="h-7 w-7 text-emerald-700" />
+      </div>
+
+      <h2 className="text-2xl sm:text-3xl font-semibold text-gray-900 mb-3">
+        Às vezes, conversar é o melhor começo
+      </h2>
+      <p className="text-lg text-gray-600 mb-8 leading-relaxed">
+        Pelo que você compartilhou, acho que vale a pena trocarmos uma ideia antes.
+        Vou te conectar com alguém da nossa equipe pra te ouvir com calma.
+      </p>
+
+      <div className="flex flex-col sm:flex-row gap-3 justify-center items-center">
+        <WhatsAppButton
+          source="triagem_redirect"
+          label="Falar no WhatsApp"
+          message="Oi! Fiz a triagem no site e preferi conversar antes de escolher um psicólogo."
+          size="lg"
+          className="px-8 bg-emerald-600 hover:bg-emerald-700 text-white border-emerald-600"
+        />
+        <Button
+          variant="outline"
+          size="lg"
+          onClick={() => navigate('/#terapeutas')}
+          className="px-8"
+        >
+          <Users className="h-4 w-4 mr-2" />
+          Prefiro ver a lista mesmo assim
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/MatchingPage.jsx
+++ b/src/pages/MatchingPage.jsx
@@ -7,7 +7,7 @@ import TherapistFinder from '../components/therapist-finder/TherapistFinder.jsx'
 
 export default function MatchingPage() {
   const location = useLocation()
-  const { formData, priorityTherapistId } = location.state || {}
+  const { formData, priorityTherapistId, initialFilters } = location.state || {}
   const isLoggedIn = authService.isLoggedIn()
 
   return (
@@ -28,6 +28,7 @@ export default function MatchingPage() {
             <TherapistFinder
               showPrompt={false}
               priorityTherapistId={priorityTherapistId}
+              initialFilters={initialFilters}
               heading=""
               subheading=""
               pageSize={6}

--- a/src/pages/TriagePage.jsx
+++ b/src/pages/TriagePage.jsx
@@ -1,0 +1,24 @@
+import { Link } from 'react-router-dom'
+import TriageFlow from '../components/triage/TriageFlow.jsx'
+import horizontalLogo from '../assets/horizontal-logo.png'
+
+export default function TriagePage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-green-50">
+      <header className="bg-white/80 backdrop-blur border-b border-gray-100 sticky top-0 z-10">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-3 flex items-center justify-between">
+          <Link to="/" className="flex items-center">
+            <img src={horizontalLogo} alt="Terapia Conecta" className="h-8 w-auto" />
+          </Link>
+          <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">
+            Sair
+          </Link>
+        </div>
+      </header>
+
+      <main className="py-12 px-4 sm:px-6 lg:px-8">
+        <TriageFlow />
+      </main>
+    </div>
+  )
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -30,6 +30,7 @@ import HrDashboardPage from './pages/HrDashboardPage.jsx'
 import CompanyAuthGate from './components/CompanyAuthGate.jsx'
 import EnigmaQuizPage from './pages/EnigmaQuizPage.jsx'
 import AdminPage from './pages/AdminPage.jsx'
+import TriagePage from './pages/TriagePage.jsx'
 
 export const router = createBrowserRouter([
   {
@@ -155,5 +156,9 @@ export const router = createBrowserRouter([
   {
     path: "/admin",
     element: <AdminPage />
+  },
+  {
+    path: "/triagem",
+    element: <TriagePage />
   }
 ])

--- a/src/services/triageFeedbackService.js
+++ b/src/services/triageFeedbackService.js
@@ -1,0 +1,8 @@
+import api from './api.js'
+
+// Sends aggregated feedback about a triage result. Backend strict-mode
+// rejects anything beyond tema + resposta. See
+// docs/triagem-terapiaconecta.md for the privacy contract.
+export async function submitTriageFeedback({ tema, resposta }) {
+  return api.post('/triage_feedback', { tema, resposta })
+}

--- a/src/utils/triage-matrix.js
+++ b/src/utils/triage-matrix.js
@@ -1,0 +1,188 @@
+// Triage flow data + matching logic. Pure functions — no side effects, no
+// network calls. State lives in React; nothing here writes to URL, storage,
+// or network. See docs/triagem-terapiaconecta.md for the design contract.
+
+export const QUESTIONS = {
+  p1: {
+    key: 'p1',
+    number: 1,
+    text: 'O que mais descreve como você tem se sentido?',
+    skippable: false,
+    options: [
+      { id: 'ansioso',        label: 'Ansioso, tenso, com a cabeça acelerada' },
+      { id: 'triste',         label: 'Triste, sem energia, desanimado' },
+      { id: 'raiva',          label: 'Com raiva, irritado, no limite' },
+      { id: 'perdido',        label: 'Perdido, confuso, sem saber quem sou' },
+      { id: 'sobrecarregado', label: 'Sobrecarregado, no automático, exausto' },
+      { id: 'machucado',      label: 'Machucado por algo que aconteceu' },
+    ],
+  },
+  p2: {
+    key: 'p2',
+    number: 2,
+    text: 'Onde isso mais aparece na sua vida?',
+    skippable: false,
+    options: [
+      { id: 'trabalho',        label: 'No trabalho ou nos estudos' },
+      { id: 'relacionamentos', label: 'Nos meus relacionamentos (família, parceiro, amigos)' },
+      { id: 'eu_mesmo',        label: 'Na relação comigo mesmo' },
+      { id: 'filhos',          label: 'Na maternidade/paternidade ou com meus filhos' },
+      { id: 'perda_mudanca',   label: 'Depois de uma perda ou mudança grande' },
+      { id: 'todo_lugar',      label: 'Em todo lugar, não consigo identificar' },
+    ],
+  },
+  p3: {
+    key: 'p3',
+    number: 3,
+    text: 'O que você mais quer da terapia agora?',
+    skippable: true,
+    options: [
+      { id: 'lidar_melhor',  label: 'Lidar melhor com o que estou sentindo' },
+      { id: 'entender',      label: 'Entender o que está acontecendo comigo' },
+      { id: 'atravessar',    label: 'Atravessar uma fase difícil específica' },
+      { id: 'mudar_padroes', label: 'Mudar padrões que se repetem na minha vida' },
+      { id: 'falar_espaco',  label: 'Só quero um espaço pra falar, sem pressão' },
+    ],
+  },
+}
+
+// Doc-form theme IDs (used in matrix + analytics for stability)
+export const THEMES = {
+  ANSIEDADE_ESTRESSE:        'ansiedade_estresse',
+  DEPRESSAO_TRISTEZA:        'depressao_tristeza',
+  LUTO_PERDAS:               'luto_perdas',
+  RELACIONAMENTOS_FAMILIA:   'relacionamentos_familia',
+  TRAUMA_VIOLENCIA:          'trauma_violencia',
+  AUTOCONHECIMENTO:          'autoconhecimento',
+  TRABALHO_CARREIRA:         'trabalho_carreira',
+  NEURODIVERGENCIA_ATIPICOS: 'neurodivergencia_atipicos',
+}
+
+// Matrix IDs → backend DB slugs. Keep this in sync with themes:seed output.
+export const THEME_SLUG_MAP = {
+  ansiedade_estresse:        'ansiedade-estresse',
+  depressao_tristeza:        'depressao-tristeza',
+  luto_perdas:               'luto-perdas',
+  relacionamentos_familia:   'relacionamentos-familia',
+  trauma_violencia:          'trauma-violencia',
+  autoconhecimento:          'autoconhecimento-autoestima',
+  trabalho_carreira:         'trabalho-carreira',
+  neurodivergencia_atipicos: 'neurodivergencia-filhos',
+}
+
+// Human-readable display names for the result screen — same as the 8 themes
+// seeded in the backend but referenced by matrix ID for consistency.
+export const THEME_DISPLAY_NAME = {
+  ansiedade_estresse:        'Ansiedade e estresse',
+  depressao_tristeza:        'Depressão e tristeza profunda',
+  luto_perdas:               'Luto e perdas',
+  relacionamentos_familia:   'Relacionamentos e família',
+  trauma_violencia:          'Trauma e violência',
+  autoconhecimento:          'Autoconhecimento e autoestima',
+  trabalho_carreira:         'Trabalho e carreira',
+  neurodivergencia_atipicos: 'Neurodivergência e filhos atípicos',
+}
+
+export const MATRIZ_TEMAS = {
+  // ANSIOSO
+  'ansioso+trabalho':        { ansiedade_estresse: 0.6, trabalho_carreira: 0.4 },
+  'ansioso+relacionamentos': { ansiedade_estresse: 0.7, relacionamentos_familia: 0.3 },
+  'ansioso+eu_mesmo':        { ansiedade_estresse: 0.8, autoconhecimento: 0.2 },
+  'ansioso+filhos':          { ansiedade_estresse: 0.5, neurodivergencia_atipicos: 0.5 },
+  'ansioso+perda_mudanca':   { ansiedade_estresse: 0.6, luto_perdas: 0.4 },
+  'ansioso+todo_lugar':      { redirecionar_whatsapp: 1.0 },
+
+  // TRISTE
+  'triste+trabalho':        { depressao_tristeza: 0.6, trabalho_carreira: 0.4 },
+  'triste+relacionamentos': { depressao_tristeza: 0.6, relacionamentos_familia: 0.4 },
+  'triste+eu_mesmo':        { depressao_tristeza: 0.7, autoconhecimento: 0.3 },
+  'triste+filhos':          { depressao_tristeza: 0.5, neurodivergencia_atipicos: 0.5 },
+  'triste+perda_mudanca':   { luto_perdas: 0.7, depressao_tristeza: 0.3 },
+  'triste+todo_lugar':      { redirecionar_whatsapp: 1.0 },
+
+  // RAIVA
+  'raiva+trabalho':        { trabalho_carreira: 0.6, ansiedade_estresse: 0.4 },
+  'raiva+relacionamentos': { relacionamentos_familia: 0.8, autoconhecimento: 0.2 },
+  'raiva+eu_mesmo':        { autoconhecimento: 0.7, ansiedade_estresse: 0.3 },
+  'raiva+filhos':          { relacionamentos_familia: 0.5, neurodivergencia_atipicos: 0.5 },
+  'raiva+perda_mudanca':   { luto_perdas: 0.6, autoconhecimento: 0.4 },
+  'raiva+todo_lugar':      { redirecionar_whatsapp: 1.0 },
+
+  // PERDIDO
+  'perdido+trabalho':        { autoconhecimento: 0.6, trabalho_carreira: 0.4 },
+  'perdido+relacionamentos': { autoconhecimento: 0.6, relacionamentos_familia: 0.4 },
+  'perdido+eu_mesmo':        { autoconhecimento: 1.0 },
+  'perdido+filhos':          { autoconhecimento: 0.5, neurodivergencia_atipicos: 0.5 },
+  'perdido+perda_mudanca':   { autoconhecimento: 0.6, luto_perdas: 0.4 },
+  'perdido+todo_lugar':      { redirecionar_whatsapp: 1.0 },
+
+  // SOBRECARREGADO
+  'sobrecarregado+trabalho':        { trabalho_carreira: 0.7, ansiedade_estresse: 0.3 },
+  'sobrecarregado+relacionamentos': { relacionamentos_familia: 0.6, ansiedade_estresse: 0.4 },
+  'sobrecarregado+eu_mesmo':        { ansiedade_estresse: 0.6, autoconhecimento: 0.4 },
+  'sobrecarregado+filhos':          { neurodivergencia_atipicos: 0.7, ansiedade_estresse: 0.3 },
+  'sobrecarregado+perda_mudanca':   { luto_perdas: 0.5, ansiedade_estresse: 0.5 },
+  'sobrecarregado+todo_lugar':      { redirecionar_whatsapp: 1.0 },
+
+  // MACHUCADO
+  'machucado+trabalho':        { trauma_violencia: 0.7, trabalho_carreira: 0.3 },
+  'machucado+relacionamentos': { trauma_violencia: 0.6, relacionamentos_familia: 0.4 },
+  'machucado+eu_mesmo':        { trauma_violencia: 0.8, autoconhecimento: 0.2 },
+  'machucado+filhos':          { trauma_violencia: 0.5, relacionamentos_familia: 0.5 },
+  'machucado+perda_mudanca':   { luto_perdas: 0.8, trauma_violencia: 0.2 },
+  'machucado+todo_lugar':      { redirecionar_whatsapp: 1.0 },
+}
+
+// P3 → preferred therapeutic approaches. Collected but NOT used in MVP
+// ranking (requires abordagens field on Therapist model — deferred).
+export const MODIFICADOR_ABORDAGEM = {
+  lidar_melhor:  ['TCC', 'ACT', 'breve_focal'],
+  entender:      ['psicanalitica', 'psicodinamica'],
+  atravessar:    ['breve_focal', 'centrada_pessoa'],
+  mudar_padroes: ['psicanalitica', 'psicodinamica', 'esquemas'],
+  falar_espaco:  ['centrada_pessoa', 'humanista', 'gestaltica'],
+}
+
+/**
+ * Maps (p1, p2, p3) answers to a theme matching result.
+ * @param {string} p1
+ * @param {string} p2
+ * @param {string|null} p3 - optional (skippable)
+ * @returns {{ tipo: 'redirecionar' } | { tipo: 'resultado', temaPrincipal, temaSecundario, abordagensPreferenciais }}
+ */
+export function resolverTema(p1, p2, p3) {
+  const chave = `${p1}+${p2}`
+  const pesos = MATRIZ_TEMAS[chave]
+
+  if (!pesos || pesos.redirecionar_whatsapp) {
+    return { tipo: 'redirecionar' }
+  }
+
+  const sortedThemes = Object.entries(pesos).sort((a, b) => b[1] - a[1])
+  const temaPrincipal = sortedThemes[0]?.[0] ?? null
+  const temaSecundario = sortedThemes[1]?.[0] ?? null
+
+  if (!temaPrincipal) {
+    return { tipo: 'redirecionar' }
+  }
+
+  return {
+    tipo: 'resultado',
+    temaPrincipal,
+    temaSecundario,
+    abordagensPreferenciais: p3 ? (MODIFICADOR_ABORDAGEM[p3] ?? []) : [],
+  }
+}
+
+/**
+ * Fisher-Yates with jitter for equitable ordering of tied/equivalent records.
+ * Pure — doesn't mutate input.
+ */
+export function shuffleForEquity(arr) {
+  const copy = [...arr]
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[copy[i], copy[j]] = [copy[j], copy[i]]
+  }
+  return copy
+}


### PR DESCRIPTION
## Summary

New \`/triagem\` route implementing the 3-question guided flow from \`docs/triagem-terapiaconecta.md\`. Designed for users who arrive without being able to name what they feel — common for people in acute distress, where the 8-theme filter is too much cognitive load.

## Privacy contract (verified against the design doc)

- State lives in React \`useReducer\` — **never** written to URL, localStorage, sessionStorage, or backend
- Closing the tab wipes everything; reopening restarts from intro
- Only aggregate feedback (thumbs-up / maybe / thumbs-down) touches the network, via a single POST with only \`{tema, resposta}\`. No identifiers.
- Explicit privacy notice in Tela 0 before the first question

## Flow

\`intro → p1 → p2 → p3 → result_match\` (Caminho A) | \`result_redirect\` (Caminho B)

- \`todo_lugar\` on P2 → **always** routes to WhatsApp (acute/diffuse signal deserves a human)
- Skipping P1 or P2 → WhatsApp (can't match without them)
- Skipping P3 → matches without the \`abordagensPreferenciais\` modifier
- Unmapped matrix combination → WhatsApp fallback
- Successful match → top 3 therapists (union of principal + secondary theme), shuffled with jitter for equity

## What's NOT yet wired

Per our earlier discussion: P3 \`abordagensPreferenciais\` is **collected** but not yet used for ranking. Requires an \`abordagens\` field on \`Therapist\` + admin UI + seed vocabulary. Planned as the next feature.

Current ranking: shuffleForEquity across the full backend-filtered union, slice top 3. The doc's principal-vs-secondary weighting is a follow-up that needs per-therapist theme membership exposed on the API.

## Entry points

- **5th prompt tile** on home: "Não sei por onde começar — a gente te ajuda em 3 perguntas" (Compass icon, highlighted in emerald, full-width to read as the softer alternative)
- **Discreet link** under the FilterBar: "Nenhum desses te descreve? Responda 3 perguntas →"

## Accessibility

- Semantic buttons throughout (no \`<div onClick>\`)
- Focus ring on all interactive controls
- Progress bar with \`role="progressbar"\` + \`aria-valuenow\`
- Step heading auto-focuses on screen change (\`ref.focus()\`)
- \`aria-live="polite"\` on progress text
- Keyboard-navigable end-to-end

## Analytics

- \`Triage Start\`, \`Triage Answer\`, \`Triage Skip\`, \`Triage Result Shown\`, \`Triage Feedback\` — all via existing \`track()\` wrapper. No user-level data, only enum answers.

## Depends on

Backend PR: https://github.com/monoxchd/psicologia-platform-api/pull/50

Merge backend first; frontend works gracefully if feedback endpoint is unreachable (silently noted in UI, nothing persisted).

## Test plan

- [ ] \`npm run dev\` → visit \`/triagem\` directly. Tela 0 shows privacy notice. "Começar" advances to P1.
- [ ] Answer P1 (\`ansioso\`) + P2 (\`trabalho\`) + P3 (\`lidar_melhor\`) → result shows "Ansiedade e estresse" with 3 therapists.
- [ ] Answer P1 (\`ansioso\`) + P2 (\`todo_lugar\`) → immediately redirects to WhatsApp screen (doesn't show P3).
- [ ] Skip P1 → WhatsApp redirect.
- [ ] Skip P3 only → still returns a match (just no modifier).
- [ ] Back button: on P2, click Back → returns to P1 with answer cleared. Disabled on P1.
- [ ] Click each feedback button → POSTs to \`/triage_feedback\`; UI locks subsequent clicks.
- [ ] Refresh page mid-flow → restarts from intro (no state recovered). Confirms privacy.
- [ ] Home page: 5th tile renders, click routes to \`/triagem\`. FilterBar link renders, click routes to \`/triagem\`.
- [ ] Keyboard: tab through all screens, Enter on buttons, no trapped focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)