### PR TITLE
fix: show acolhimento price with 2 decimals in Brazilian format

### DIFF
--- a/src/components/TherapistsList.jsx
+++ b/src/components/TherapistsList.jsx
@@ -151,7 +151,7 @@ function TherapistsList() {
                 <div className="space-y-2 pt-2 mt-auto">
                   {!authService.isLoggedIn() && therapist.acolhimentoPrice && (
                     <div className="text-xs text-emerald-700 bg-emerald-50 rounded-md px-2 py-1.5 text-center">
-                      Sessão de Acolhimento: R$ {therapist.acolhimentoPrice.toFixed(0)} · via WhatsApp
+                      Sessão de Acolhimento: R$ {therapist.acolhimentoPrice.toFixed(2).replace('.', ',')} · via WhatsApp
                     </div>
                   )}
                   <Button

--- a/src/components/therapist-finder/TherapistCard.jsx
+++ b/src/components/therapist-finder/TherapistCard.jsx
@@ -182,7 +182,7 @@ export default function TherapistCard({ therapist, index }) {
         <div className="space-y-2 pt-2 mt-auto">
           {!loggedIn && therapist.acolhimentoPrice && (
             <div className="text-xs text-emerald-700 bg-emerald-50 rounded-md px-2 py-1.5 text-center">
-              Sessão de Acolhimento: R$ {therapist.acolhimentoPrice.toFixed(0)} · via WhatsApp
+              Sessão de Acolhimento: R$ {therapist.acolhimentoPrice.toFixed(2).replace('.', ',')} · via WhatsApp
             </div>
           )}
           <Button className="w-full" onClick={handleScheduleClick}>


### PR DESCRIPTION
## Summary

Tiny rounding fix on the post-V1 acolhimento chip. Prices entered in admin like `94,90` were displaying as `R$ 95` on the public therapist cards because the format used `.toFixed(0)`.

Switch to `.toFixed(2).replace('.', ',')` so the displayed value matches Brazilian formatting and respects the cents the therapist set.

**Before:** `Sessão de Acolhimento: R$ 95 · via WhatsApp`
**After:** `Sessão de Acolhimento: R$ 94,90 · via WhatsApp`

Affects two files (same chip rendered in two surfaces):
- `src/components/TherapistsList.jsx`
- `src/components/therapist-finder/TherapistCard.jsx`

## Test plan

- [ ] Set a therapist's `acolhimento_price` to `94.90` in admin
- [ ] Visit `/` (or any list using `TherapistsList` / `TherapistCard`) as a logged-out user
- [ ] Confirm the green chip shows `R$ 94,90` and not `R$ 95`

🤖 Generated with [Claude Code](https://claude.com/claude-code)